### PR TITLE
res_vs_temp overhaul

### DIFF
--- a/citkid/res_vs_temp/data_io.py
+++ b/citkid/res_vs_temp/data_io.py
@@ -1,19 +1,19 @@
 import pandas as pd
 import numpy as np
 
-f_vs_T_names = ['fr0', 'alpha', 'Tc', 'Fdelta0']
-f_vs_T_labels = [r'$f_r^0$', r'$\alpha$', r'$T_c$', r'$F\delta_0$']
-f_vs_T_qp_names = ['fr0', 'alpha', 'Tc']
-f_vs_T_qp_labels = [r'$f_r^0$', r'$\alpha$', r'$T_c$']
-f_vs_T_tls_names = ['fr0', 'Fdelta0']
-f_vs_T_tls_labels = [r'$f_r^0$', r'$F\delta_0$']
-Q_vs_T_names = ['fr0', 'alpha', 'Tc', 'Fdelta0', 'delta_z']
-Q_vs_T_labels = [r'$f_r^0$', r'$\alpha$', r'$T_c$', r'$F\delta_0$',
+f_vs_T_names = ['f0', 'alpha', 'Tc', 'Fdelta0']
+f_vs_T_labels = [r'$f_0$', r'$\alpha$', r'$T_c$', r'$F\delta_0$']
+f_vs_T_qp_names = ['f0', 'alpha', 'Tc']
+f_vs_T_qp_labels = [r'$f_0$', r'$\alpha$', r'$T_c$']
+f_vs_T_tls_names = ['f0', 'Fdelta0']
+f_vs_T_tls_labels = [r'$f_0$', r'$F\delta_0$']
+Q_vs_T_names = ['f0', 'alpha', 'Tc', 'Fdelta0', 'delta_z']
+Q_vs_T_labels = [r'$f_0$', r'$\alpha$', r'$T_c$', r'$F\delta_0$',
                  r'$\delta_z$']
-Q_vs_T_qp_names = ['fr0', 'alpha', 'Tc', 'delta_z']
-Q_vs_T_qp_labels = [r'$f_r^0$', r'$\alpha$', r'$T_c$', r'$\delta_z$']
-Q_vs_T_tls_names = ['fr0', 'Fdelta0', 'delta_z']
-Q_vs_T_tls_labels = [r'$f_r^0$', r'$F\delta_0$', r'$\delta_z$']
+Q_vs_T_qp_names = ['f0', 'alpha', 'Tc', 'delta_z']
+Q_vs_T_qp_labels = [r'$f_0$', r'$\alpha$', r'$T_c$', r'$\delta_z$']
+Q_vs_T_tls_names = ['f0', 'Fdelta0', 'delta_z']
+Q_vs_T_tls_labels = [r'$f_0$', r'$F\delta_0$', r'$\delta_z$']
 
 ################################################################################
 ############### Resonance shift from thermal QP density and TLS ################

--- a/citkid/res_vs_temp/data_io.py
+++ b/citkid/res_vs_temp/data_io.py
@@ -1,21 +1,27 @@
 import pandas as pd
 import numpy as np
 
-fr_vs_temp_names = ['fr0', 'D', 'alpha', 'Tc']
-fr_vs_temp_labels = [r'$f_r^0$', r'$D$', r'$\alpha$', r'$T_c$']
-fr_vs_temp_notls_names = ['fr0', 'alpha', 'Tc']
-fr_vs_temp_notls_labels = [r'$f_r^0$', r'$\alpha$', r'$T_c$']
-fr_vs_temp_tls_names = ['fr0', 'D']
-fr_vs_temp_tls_labels = [r'$f_r^0$', r'$D$']
+f_vs_T_names = ['fr0', 'alpha', 'Tc', 'Fdelta0']
+f_vs_T_labels = [r'$f_r^0$', r'$\alpha$', r'$T_c$', r'$F\delta_0$']
+f_vs_T_qp_names = ['fr0', 'alpha', 'Tc']
+f_vs_T_qp_labels = [r'$f_r^0$', r'$\alpha$', r'$T_c$']
+f_vs_T_tls_names = ['fr0', 'Fdelta0']
+f_vs_T_tls_labels = [r'$f_r^0$', r'$F\delta_0$']
+Q_vs_T_names = ['fr0', 'alpha', 'Tc', 'Fdelta0', 'delta_z']
+Q_vs_T_labels = [r'$f_r^0$', r'$\alpha$', r'$T_c$', r'$F\delta_0$',
+                 r'$\delta_z$']
+Q_vs_T_qp_names = ['fr0', 'alpha', 'Tc', 'delta_z']
+Q_vs_T_qp_labels = [r'$f_r^0$', r'$\alpha$', r'$T_c$', r'$\delta_z$']
+Q_vs_T_tls_names = ['fr0', 'Fdelta0', 'delta_z']
+Q_vs_T_tls_labels = [r'$f_r^0$', r'$F\delta_0$', r'$\delta_z$']
 
-Q_vs_temp_notls_names = ['fr0', 'alpha', 'Tc', 'delta_z']
-Q_vs_temp_notls_labels = [r'$f_r^0$', r'$\alpha$', r'$T_c$', r'$\delta_z$']
-
-
-def make_fit_row_fr_vs_temp(p0, popt, perr, gamma, plot_path = '',
-                            prefix = 'fr_vs_temp'):
+################################################################################
+############### Resonance shift from thermal QP density and TLS ################
+################################################################################
+def make_fit_row_f_vs_T(p0, popt, perr, gamma, plot_path = '',
+                            prefix = 'f_vs_T'):
     """
-    Wraps the output of fit_fr_vs_temp fitting into a pd.Series instance
+    Wraps the output of fit_f_vs_T fitting into a pd.Series instance
 
     Parameters:
     p0 (np.array): fit parameter guess
@@ -24,7 +30,7 @@ def make_fit_row_fr_vs_temp(p0, popt, perr, gamma, plot_path = '',
     gamma (float): 1, 1/2, or 1/3 for thin-film, local, or anomalous limits
     plot_path (str): path to the saved plot, or empty string if it does not
         exists
-    prefix (str): prefix for the column names. default is 'fr_vs_temp'
+    prefix (str): prefix for the column names. default is 'f_vs_T'
 
     Returns:
     row (pd.Series): pd.Series object that includes all of the input data
@@ -32,23 +38,23 @@ def make_fit_row_fr_vs_temp(p0, popt, perr, gamma, plot_path = '',
     if len(prefix):
         prefix += '_'
     row = pd.Series(dtype = float)
-    for key, pi in zip(fr_vs_temp_names, p0):
+    for key, pi in zip(f_vs_T_names, p0):
         row[prefix + key + '_guess'] = pi
-    for key, pi in zip(fr_vs_temp_names, popt):
+    for key, pi in zip(f_vs_T_names, popt):
         row[prefix + key] = pi
-    for key, pi in zip(fr_vs_temp_names, perr):
+    for key, pi in zip(f_vs_T_names, perr):
         row[prefix + key + '_err'] = pi
     row[prefix + 'gamma'] = gamma
     row[prefix + 'plotpath'] = plot_path
     return row
 
-def separate_fit_row_fr_vs_temp(row, prefix = 'fr_vs_temp'):
+def separate_fit_row_f_vs_T(row, prefix = 'f_vs_T'):
     """
-    Performs the inverse function of make_fit_row_fr_vs_temp
+    Performs the inverse function of make_fit_row_f_vs_T.
 
     Parameters:
     row (pd.Series): pd.Series object that includes all of the input data
-    prefix (str): prefix for the column names. default is 'fr_vs_temp'
+    prefix (str): prefix for the column names. default is 'f_vs_T'
 
     Returns:
     p0 (np.array): fit parameter guess
@@ -61,13 +67,75 @@ def separate_fit_row_fr_vs_temp(row, prefix = 'fr_vs_temp'):
     if len(prefix):
         prefix += '_'
     p0 = []
-    for key in fr_vs_temp_names:
+    for key in f_vs_T_names:
         p0.append(row[prefix + key + '_guess'])
     popt = []
-    for key in fr_vs_temp_names:
+    for key in f_vs_T_names:
         popt.append(row[prefix + key])
     perr = []
-    for key in fr_vs_temp_names:
+    for key in f_vs_T_names:
+        perr.append(row[prefix + key + '_err'])
+    plot_path = row[prefix + 'plotpath']
+    p0, popt, perr = np.array(p0), np.array(popt), np.array(perr)
+    gamma = row[prefix + 'gamma']
+    return p0, popt, perr, gamma, plot_path
+
+def make_fit_row_Q_vs_T(p0, popt, perr, gamma, plot_path = '',
+                            prefix = 'Q_vs_T'):
+    """
+    Wraps the output of fit_Q_vs_T fitting into a pd.Series instance
+
+    Parameters:
+    p0 (np.array): fit parameter guess
+    popt (np.array): fit parameters
+    perr (np.array): standard errors on fit parameters
+    gamma (float): 1, 1/2, or 1/3 for thin-film, local, or anomalous limits
+    plot_path (str): path to the saved plot, or empty string if it does not
+        exists
+    prefix (str): prefix for the column names. default is 'Q_vs_T'
+
+    Returns:
+    row (pd.Series): pd.Series object that includes all of the input data
+    """
+    if len(prefix):
+        prefix += '_'
+    row = pd.Series(dtype = float)
+    for key, pi in zip(Q_vs_T_names, p0):
+        row[prefix + key + '_guess'] = pi
+    for key, pi in zip(Q_vs_T_names, popt):
+        row[prefix + key] = pi
+    for key, pi in zip(Q_vs_T_names, perr):
+        row[prefix + key + '_err'] = pi
+    row[prefix + 'gamma'] = gamma
+    row[prefix + 'plotpath'] = plot_path
+    return row
+
+def separate_fit_row_Q_vs_T(row, prefix = 'Q_vs_T'):
+    """
+    Performs the inverse function of make_fit_row_Q_vs_T.
+
+    Parameters:
+    row (pd.Series): pd.Series object that includes all of the input data
+    prefix (str): prefix for the column names. default is 'Q_vs_T'
+
+    Returns:
+    p0 (np.array): fit parameter guess
+    popt (np.array): fit parameters
+    perr (np.array): standard errors on fit parameters
+    gamma (float): 1, 1/2, or 1/3 for thin-film, local, or anomalous limits
+    plot_path (str): path to the saved plot, or empty string if it does not
+        exists
+    """
+    if len(prefix):
+        prefix += '_'
+    p0 = []
+    for key in Q_vs_T_names:
+        p0.append(row[prefix + key + '_guess'])
+    popt = []
+    for key in Q_vs_T_names:
+        popt.append(row[prefix + key])
+    perr = []
+    for key in Q_vs_T_names:
         perr.append(row[prefix + key + '_err'])
     plot_path = row[prefix + 'plotpath']
     p0, popt, perr = np.array(p0), np.array(popt), np.array(perr)
@@ -75,12 +143,12 @@ def separate_fit_row_fr_vs_temp(row, prefix = 'fr_vs_temp'):
     return p0, popt, perr, gamma, plot_path
 
 ################################################################################
-######################### Funcs without TLS component ##########################
+################### Resonance shift from thermal QP density ####################
 ################################################################################
-def make_fit_row_fr_vs_temp_notls(p0, popt, perr, gamma, plot_path = '',
-                                  prefix = 'fr_vs_temp_notls'):
+def make_fit_row_f_vs_T_qp(p0, popt, perr, gamma, plot_path = '',
+                                  prefix = 'f_vs_T_qp'):
     """
-    Wraps the output of fit_fr_vs_temp_notls fitting into a pd.Series instance
+    Wraps the output of fit_f_vs_T_qp fitting into a pd.Series instance.
 
     Parameters:
     p0 (np.array): fit parameter guess
@@ -89,7 +157,7 @@ def make_fit_row_fr_vs_temp_notls(p0, popt, perr, gamma, plot_path = '',
     gamma (float): 1, 1/2, or 1/3 for thin-film, local, or anomalous limits
     plot_path (str): path to the saved plot, or empty string if it does not
         exists
-    prefix (str): prefix for the column names. default is 'fr_vs_temp_notls'
+    prefix (str): prefix for the column names. default is 'f_vs_T_qp'
 
     Returns:
     row (pd.Series): pd.Series object that includes all of the input data
@@ -97,23 +165,23 @@ def make_fit_row_fr_vs_temp_notls(p0, popt, perr, gamma, plot_path = '',
     if len(prefix):
         prefix += '_'
     row = pd.Series(dtype = float)
-    for key, pi in zip(fr_vs_temp_notls_names, p0):
+    for key, pi in zip(f_vs_T_qp_names, p0):
         row[prefix + key + '_guess'] = pi
-    for key, pi in zip(fr_vs_temp_notls_names, popt):
+    for key, pi in zip(f_vs_T_qp_names, popt):
         row[prefix + key] = pi
-    for key, pi in zip(fr_vs_temp_notls_names, perr):
+    for key, pi in zip(f_vs_T_qp_names, perr):
         row[prefix + key + '_err'] = pi
     row[prefix + 'gamma'] = gamma
     row[prefix + 'plotpath'] = plot_path
     return row
 
-def separate_fit_row_fr_vs_temp_notls(row, prefix = 'fr_vs_temp_notls'):
+def separate_fit_row_f_vs_T_qp(row, prefix = 'f_vs_T_qp'):
     """
-    Performs the inverse function of make_fit_row_fr_vs_temp_notls
+    Performs the inverse function of make_fit_row_f_vs_T_qp.
 
     Parameters:
     row (pd.Series): pd.Series object that includes all of the input data
-    prefix (str): prefix for the column names. default is 'fr_vs_temp_notls'
+    prefix (str): prefix for the column names. default is 'f_vs_T_qp'
 
     Returns:
     p0 (np.array): fit parameter guess
@@ -126,33 +194,32 @@ def separate_fit_row_fr_vs_temp_notls(row, prefix = 'fr_vs_temp_notls'):
     if len(prefix):
         prefix += '_'
     p0 = []
-    for key in fr_vs_temp_notls_names:
+    for key in f_vs_T_qp_names:
         p0.append(row[prefix + key + '_guess'])
     popt = []
-    for key in fr_vs_temp_notls_names:
+    for key in f_vs_T_qp_names:
         popt.append(row[prefix + key])
     perr = []
-    for key in fr_vs_temp_notls_names:
+    for key in f_vs_T_qp_names:
         perr.append(row[prefix + key + '_err'])
     plot_path = row[prefix + 'plotpath']
     p0, popt, perr = np.array(p0), np.array(popt), np.array(perr)
     gamma = row[prefix + 'gamma']
     return p0, popt, perr, gamma, plot_path
 
-def make_fit_row_Q_vs_temp_notls(p0, popt, perr, gamma, N0, plot_path = '',
-                                 prefix = 'Q_vs_temp_notls'):
+def make_fit_row_Q_vs_T_qp(p0, popt, perr, gamma, plot_path = '',
+                                 prefix = 'Q_vs_T_qp'):
     """
-    Wraps the output of fit_Q_vs_temp_notls fitting into a pd.Series instance
+    Wraps the output of fit_Q_vs_T_qp fitting into a pd.Series instance.
 
     Parameters:
     p0 (np.array): fit parameter guess
     popt (np.array): fit parameters
     perr (np.array): standard errors on fit parameters
     gamma (float): 1, 1/2, or 1/3 for thin-film, local, or anomalous limits
-    N0 (float): single-spin density of states at the Fermi Level
     plot_path (str): path to the saved plot, or empty string if it does not
         exists
-    prefix (str): prefix for the column names. default is 'Q_vs_temp_notls'
+    prefix (str): prefix for the column names. default is 'Q_vs_T_qp'
 
     Returns:
     row (pd.Series): pd.Series object that includes all of the input data
@@ -160,58 +227,55 @@ def make_fit_row_Q_vs_temp_notls(p0, popt, perr, gamma, N0, plot_path = '',
     if len(prefix):
         prefix += '_'
     row = pd.Series(dtype = float)
-    for key, pi in zip(Q_vs_temp_notls_names, p0):
+    for key, pi in zip(Q_vs_T_qp_names, p0):
         row[prefix + key + '_guess'] = pi
-    for key, pi in zip(Q_vs_temp_notls_names, popt):
+    for key, pi in zip(Q_vs_T_qp_names, popt):
         row[prefix + key] = pi
-    for key, pi in zip(Q_vs_temp_notls_names, perr):
+    for key, pi in zip(Q_vs_T_qp_names, perr):
         row[prefix + key + '_err'] = pi
     row[prefix + 'gamma'] = gamma
-    row[prefix + 'N0'] = N0
     row[prefix + 'plotpath'] = plot_path
     return row
 
-def separate_fit_row_Q_vs_temp_notls(row, prefix = 'Q_vs_temp_notls'):
+def separate_fit_row_Q_vs_T_qp(row, prefix = 'Q_vs_T_qp'):
     """
-    Performs the inverse function of make_fit_row_Q_vs_temp_notls
+    Performs the inverse function of make_fit_row_Q_vs_T_qp.
 
     Parameters:
     row (pd.Series): pd.Series object that includes all of the input data
-    prefix (str): prefix for the column names. default is 'Q_vs_temp_notls'
+    prefix (str): prefix for the column names. default is 'Q_vs_T_qp'
 
     Returns:
     p0 (np.array): fit parameter guess
     popt (np.array): fit parameters
     perr (np.array): standard errors on fit parameters
     gamma (float): 1, 1/2, or 1/3 for thin-film, local, or anomalous limits
-    N0 (float): single-spin density of states at the Fermi Level
     plot_path (str): path to the saved plot, or empty string if it does not
         exists
     """
     if len(prefix):
         prefix += '_'
     p0 = []
-    for key in Q_vs_temp_notls_names:
+    for key in Q_vs_T_qp_names:
         p0.append(row[prefix + key + '_guess'])
     popt = []
-    for key in Q_vs_temp_notls_names:
+    for key in Q_vs_T_qp_names:
         popt.append(row[prefix + key])
     perr = []
-    for key in Q_vs_temp_notls_names:
+    for key in Q_vs_T_qp_names:
         perr.append(row[prefix + key + '_err'])
     plot_path = row[prefix + 'plotpath']
     p0, popt, perr = np.array(p0), np.array(popt), np.array(perr)
     gamma = row[prefix + 'gamma']
-    N0 = row[prefix + 'N0']
-    return p0, popt, perr, gamma, N0, plot_path
+    return p0, popt, perr, gamma, plot_path
 
 ################################################################################
-######################## Funcs with only TLS component #########################
+########################### Resonance shift from TLS ###########################
 ################################################################################
-def make_fit_row_fr_vs_temp_tls(p0, popt, perr, plot_path = '',
-                            prefix = 'fr_vs_temp_tls'):
+def make_fit_row_f_vs_T_tls(p0, popt, perr, plot_path = '',
+                            prefix = 'f_vs_T_tls'):
     """
-    Wraps the output of fit_fr_vs_temp_tls fitting into a pd.Series instance
+    Wraps the output of fit_f_vs_T_tls fitting into a pd.Series instance.
 
     Parameters:
     p0 (np.array): fit parameter guess
@@ -219,7 +283,7 @@ def make_fit_row_fr_vs_temp_tls(p0, popt, perr, plot_path = '',
     perr (np.array): standard errors on fit parameters
     plot_path (str): path to the saved plot, or empty string if it does not
         exists
-    prefix (str): prefix for the column names. default is 'fr_vs_temp_tls'
+    prefix (str): prefix for the column names. default is 'f_vs_T_tls'
 
     Returns:
     row (pd.Series): pd.Series object that includes all of the input data
@@ -227,22 +291,22 @@ def make_fit_row_fr_vs_temp_tls(p0, popt, perr, plot_path = '',
     if len(prefix):
         prefix += '_'
     row = pd.Series(dtype = float)
-    for key, pi in zip(fr_vs_temp_tls_names, p0):
+    for key, pi in zip(f_vs_T_tls_names, p0):
         row[prefix + key + '_guess'] = pi
-    for key, pi in zip(fr_vs_temp_tls_names, popt):
+    for key, pi in zip(f_vs_T_tls_names, popt):
         row[prefix + key] = pi
-    for key, pi in zip(fr_vs_temp_tls_names, perr):
+    for key, pi in zip(f_vs_T_tls_names, perr):
         row[prefix + key + '_err'] = pi
     row[prefix + 'plotpath'] = plot_path
     return row
 
-def separate_fit_row_fr_vs_temp_tls(row, prefix = 'fr_vs_temp_tls'):
+def separate_fit_row_f_vs_T_tls(row, prefix = 'f_vs_T_tls'):
     """
-    Performs the inverse function of make_fit_row_fr_vs_temp_tls
+    Performs the inverse function of make_fit_row_f_vs_T_tls.
 
     Parameters:
     row (pd.Series): pd.Series object that includes all of the input data
-    prefix (str): prefix for the column names. default is 'fr_vs_temp_tls'
+    prefix (str): prefix for the column names. default is 'f_vs_T_tls'
 
     Returns:
     p0 (np.array): fit parameter guess
@@ -254,13 +318,71 @@ def separate_fit_row_fr_vs_temp_tls(row, prefix = 'fr_vs_temp_tls'):
     if len(prefix):
         prefix += '_'
     p0 = []
-    for key in fr_vs_temp_tls_names:
+    for key in f_vs_T_tls_names:
         p0.append(row[prefix + key + '_guess'])
     popt = []
-    for key in fr_vs_temp_tls_names:
+    for key in f_vs_T_tls_names:
         popt.append(row[prefix + key])
     perr = []
-    for key in fr_vs_temp_tls_names:
+    for key in f_vs_T_tls_names:
+        perr.append(row[prefix + key + '_err'])
+    plot_path = row[prefix + 'plotpath']
+    p0, popt, perr = np.array(p0), np.array(popt), np.array(perr)
+    return p0, popt, perr, plot_path
+
+def make_fit_row_Q_vs_T_tls(p0, popt, perr, plot_path = '',
+                            prefix = 'Q_vs_T_tls'):
+    """
+    Wraps the output of fit_Q_vs_T_tls fitting into a pd.Series instance.
+
+    Parameters:
+    p0 (np.array): fit parameter guess
+    popt (np.array): fit parameters
+    perr (np.array): standard errors on fit parameters
+    plot_path (str): path to the saved plot, or empty string if it does not
+        exists
+    prefix (str): prefix for the column names. default is 'Q_vs_T_tls'
+
+    Returns:
+    row (pd.Series): pd.Series object that includes all of the input data
+    """
+    if len(prefix):
+        prefix += '_'
+    row = pd.Series(dtype = float)
+    for key, pi in zip(Q_vs_T_tls_names, p0):
+        row[prefix + key + '_guess'] = pi
+    for key, pi in zip(Q_vs_T_tls_names, popt):
+        row[prefix + key] = pi
+    for key, pi in zip(Q_vs_T_tls_names, perr):
+        row[prefix + key + '_err'] = pi
+    row[prefix + 'plotpath'] = plot_path
+    return row
+
+def separate_fit_row_Q_vs_T_tls(row, prefix = 'Q_vs_T_tls'):
+    """
+    Performs the inverse function of make_fit_row_Q_vs_T_tls.
+
+    Parameters:
+    row (pd.Series): pd.Series object that includes all of the input data
+    prefix (str): prefix for the column names. default is 'Q_vs_T_tls'
+
+    Returns:
+    p0 (np.array): fit parameter guess
+    popt (np.array): fit parameters
+    perr (np.array): standard errors on fit parameters
+    plot_path (str): path to the saved plot, or empty string if it does not
+        exists
+    """
+    if len(prefix):
+        prefix += '_'
+    p0 = []
+    for key in Q_vs_T_tls_names:
+        p0.append(row[prefix + key + '_guess'])
+    popt = []
+    for key in Q_vs_T_tls_names:
+        popt.append(row[prefix + key])
+    perr = []
+    for key in Q_vs_T_tls_names:
         perr.append(row[prefix + key + '_err'])
     plot_path = row[prefix + 'plotpath']
     p0, popt, perr = np.array(p0), np.array(popt), np.array(perr)

--- a/citkid/res_vs_temp/fitter.py
+++ b/citkid/res_vs_temp/fitter.py
@@ -5,11 +5,14 @@ from .funcs import *
 from .plot import *
 from .data_io import *
 
-def fit_fr_vs_temp(temperature, fr, gamma = 1, Tc_guess = 1.3, fr_err = None,
+################################################################################
+############### Resonance shift from thermal QP density and TLS ################
+################################################################################
+def fit_f_vs_T(temperature, fr, gamma = 1, Tc_guess = 1.3, fr_err = None,
                    guess = None, enforced_alpha = None,
                    return_dataframe = False, plotq = False):
    """
-   Fits resonance frequency versus temperature data to fr_vs_temp
+   Fits resonance frequency versus temperature data to f_vs_T
 
    Parameters:
    temperature (array-like): temperature data in K
@@ -35,10 +38,10 @@ def fit_fr_vs_temp(temperature, fr, gamma = 1, Tc_guess = 1.3, fr_err = None,
    """
    temperature, fr = np.array(temperature), np.array(fr)
    if enforced_alpha is not None:
-       fit_func = lambda a, b, c, e: fr_vs_temp(a, b, c, enforced_alpha, e,
+       fit_func = lambda a, b, c, e: f_vs_T(a, b, c, enforced_alpha, e,
                                                 gamma = gamma)
    else:
-       fit_func = lambda a, b, c, d, e: fr_vs_temp(a, b, c, d, e, gamma = gamma)
+       fit_func = lambda a, b, c, d, e: f_vs_T(a, b, c, d, e, gamma = gamma)
 
    ix = np.argsort(temperature)
    temperature, fr = temperature[ix], fr[ix]
@@ -47,9 +50,9 @@ def fit_fr_vs_temp(temperature, fr, gamma = 1, Tc_guess = 1.3, fr_err = None,
    # Initial guess
    if guess is not None:
        p0 = guess
-       bounds = get_bounds_fr_vs_temp(p0)
+       bounds = get_bounds_f_vs_T(p0)
    else:
-       p0, bounds = guess_p0_fr_vs_temp(temperature, fr, Tc_guess, gamma)
+       p0, bounds = guess_p0_f_vs_T(temperature, fr, Tc_guess, gamma)
    if enforced_alpha is not None:
        p0 = np.append(p0[:2], p0[3])
        bounds[0] = np.append(bounds[0][:2], bounds[0][3])
@@ -80,234 +83,330 @@ def fit_fr_vs_temp(temperature, fr, gamma = 1, Tc_guess = 1.3, fr_err = None,
        perr = np.append(np.append(perr[:2],enforced_alpha), perr[2])
    # Plot
    if plotq:
-       fig, ax = plot_fr_vs_temp(temperature, fr, fr_err, popt, p0, gamma)
+       fig, ax = plot_f_vs_T(temperature, fr, fr_err, popt, p0, gamma)
    else:
        fig, ax = None, None
 
    if return_dataframe:
-       row = make_fit_row_fr_vs_temp(p0, popt, perr, gamma)
+       row = make_fit_row_f_vs_T(p0, popt, perr, gamma)
        return row, (fig, ax)
    return p0, popt, perr, (fig, ax)
 
 ################################################################################
-######################### Funcs without TLS component ##########################
+################### Resonance shift from thermal QP density ####################
 ################################################################################
-def fit_fr_vs_temp_notls(temperature, fr, gamma = 1, Tc_guess = 1.3,
-                         fr_err = None, guess = None, return_dataframe = False,
-                         bounds = None, Tc_min = None, plotq = False):
-   """
-   Fits resonance frequency versus temperature data to fr_vs_temp_notls
+def fit_f_vs_T_qp(T, f, gamma = 1, Tc_guess = 1.2, f_err = None, guess = None,
+                  bounds = None, return_dataframe = False, plotq = False,
+                  catch_exceptions = False):
+    """
+    Fits resonance frequency versus temperature data to f_vs_T_qp.
 
-   Parameters:
-   temperature (array-like): temperature data in K
-   fr (array-like): resonance frequency data in Hz
-   gamma (float): 1, 1/2, or 1/3 for thin-film, local, or anomalous limits
-   Tc_guess (float): guess for the critical temperature
-   fr_err (array-like or None): If not None, fr_err is the error on fr used in
+    Parameters:
+    T (array-like): temperature data in K
+    f (array-like): resonance frequency data in Hz
+    gamma (float): 1, 1/2, or 1/3 for thin-film, local, or anomalous limits
+    Tc_guess (float): guess for the critical temperature
+    f_err (array-like or None): If not None, f_err is the error on f used in
         the fitting. If None, points are weighted equally
-   guess (list or None): If not None, overwrites the initial guess. Also
+    guess (list or None): If not None, overwrites the initial guess. Also
         overwrites Tc_guess. [fr0_guess, alpha_guess, Tc_guess]
-   return_dataframe (bool): If True, returns a pandas series of the output data
+    bounds (list or None): custom bounds to overwrite the default option
+    return_dataframe (bool): If True, returns a pandas series of the output data
        instead of individual parameters
-   bounds (list or None): custom bounds to overwrite the default option 
-   Tc_min (float or None): overwrites the lower bound on Tc 
-   plotq (bool): If True, plots the fit and initial guess
+    plotq (bool): If True, plots the fit and initial guess
+    catch_exceptions (bool): If True, catches exceptions in the fitter and
+       returns nan values instead. Else, raises exceptions in the fitter
 
-   Returns:
-   p0 (list): initial guess parameters [fr0_guess, alpha_guess, Tc_guess]
-   popt (list): fit parameters [fr0, alpha, Tc]
-   perr (list): fit parameter uncertainties [fr0_err, alpha_err, Tc_err]
-   (fig, ax): pyplot figure and axis, or (None, None) if not plotq
-   """
-   temperature, fr = np.array(temperature), np.array(fr)
-   fit_func = lambda a, b, c, d: fr_vs_temp_notls(a, b, c, d, gamma = gamma)
+    Returns:
+    if return_dataframe is False:
+        p0 (list): initial guess parameters [fr0_guess, alpha_guess, Tc_guess]
+        popt (list): fit parameters [fr0, alpha, Tc]
+        perr (list): fit parameter uncertainties [fr0_err, alpha_err, Tc_err]
+    else:
+        row (pd.Series): contains p0, popt, and perr
+    (fig, ax): pyplot figure and axis, or (None, None) if not plotq
+    """
+    T, f = np.array(T), np.array(f)
+    ix = np.argsort(T)
+    T, f = T[ix], f[ix]
+    if f_err is not None:
+       f_err = np.array(f_err)[ix]
 
-   ix = np.argsort(temperature)
-   temperature, fr = temperature[ix], fr[ix]
-   if fr_err is not None:
-       fr_err = np.array(fr_err)[ix]
-   # Initial guess
-   if guess is not None:
+    fit_func = lambda a, b, c, d: f_vs_T_qp(a, b, c, d, gamma = gamma)
+    # Initial guess
+    if guess is not None:
        p0 = guess
-       bounds0 = get_bounds_fr_vs_temp_notls(p0)
-   else:
-       p0, bounds0 = guess_p0_fr_vs_temp_notls(temperature, fr, Tc_guess, gamma)
-   if bounds is None:
+       bounds0 = get_bounds_f_vs_T_qp(p0)
+    else:
+       p0, bounds0 = guess_p0_f_vs_T_qp(T, f, Tc_guess, gamma)
+    if bounds is None:
        bounds = bounds0
-   if Tc_min is not None:
-       bounds[0][2] = Tc_min
-   # Fit
-   if fr_err is None:
+    # Fit
+    if f_err is None:
        sigma = None
        p00 = p0
-   else:
-       sigma = fr_err
+    else:
+       sigma = f_err
        try:
-           p00, _ = curve_fit(fit_func, temperature, fr, sigma = None,
+          p00, _ = curve_fit(fit_func, T, f, sigma = None,
                               p0 = p0, bounds = bounds)
           # To fit with sigma, the initial guess must be really good, so
           # update the initial guess with curve_fit without sigma
-       except:
-           p00 = p0
-   try:
-       popt, pcov = curve_fit(fit_func, temperature, fr, sigma = sigma,
+       except Exception as e:
+          if not catch_exceptions:
+              raise e
+          p00 = p0
+    try:
+       popt, pcov = curve_fit(fit_func, T, f, sigma = sigma,
                               p0 = p00, bounds = bounds, absolute_sigma = True)
        perr = np.sqrt(np.diag(pcov))
-   except Exception as e:
+    except Exception as e:
+       if not catch_exceptions:
+           raise e
        popt = [np.nan, np.nan, np.nan]
        perr = [np.nan, np.nan, np.nan]
-   # Plot
-   if plotq:
-       fig, ax = plot_fr_vs_temp_notls(temperature, fr, fr_err, popt, p0, gamma)
-   else:
+    # Plot
+    if plotq:
+       fig, ax = plot_f_vs_T_qp(T, f, f_err, popt, p0, gamma)
+    else:
        fig, ax = None, None
 
-   if return_dataframe:
-       row = make_fit_row_fr_vs_temp_notls(p0, popt, perr, gamma)
+    if return_dataframe:
+       row = make_fit_row_f_vs_T_qp(p0, popt, perr, gamma)
        return row, (fig, ax)
-   return p0, popt, perr, (fig, ax)
+    return p0, popt, perr, (fig, ax)
 
-def fit_Q_vs_temp_notls(temperature, Q, fr0_guess, Q_err = None, gamma = 1,
-                        N0 = N0_Al, Tc_guess = None, guess = None,
-                        return_dataframe = False, plotq = False):
-   """
-   Fits quality factor versus temperature to Q_vs_temp_notls
+def fit_Q_vs_T_qp(T, Q, fr0_guess, gamma = 1, Tc_guess = 1.2, Q_err = None,
+                  guess = None, bounds = None, return_dataframe = False,
+                  plotq = False, catch_exceptions = False):
+    """
+    Fits quality factor versus temperature to Q_vs_T_qp
 
-   Parameters:
-   temperature (array-like): temperature data in K
-   Q (array-like): quality factor data
-   fr0_guess (float): guess for the frequency at 0 K
-   Q_err (array-like or None): If not None, Q_err is the error on Q used in
+    Parameters:
+    T (array-like): temperature data in K
+    Q (array-like): quality factor data
+    fr0_guess (float): guess for the resonant frequency in Hz at T = 0 K
+    Q_err (array-like or None): If not None, Q_err is the error on Q used in
         the fitting. If None, points are weighted equally
-   gamma (float): 1, 1/2, or 1/3 for thin-film, local, or anomalous limits
-   N0 (float): single-spin density of states at the Fermi Level
-   guess (list or None): If not None, overwrites the initial guess. Also
-        overwrites fr0_guess. [fr0_guess, D_guess]
-   return_dataframe (bool): If True, returns a pandas series of the output data
+    gamma (float): 1, 1/2, or 1/3 for thin-film, local, or anomalous limits
+    guess (list or None): If not None, overwrites the initial guess. Also
+        overwrites fr0_guess. [fr0_guess, alpha_guess, Tc_guess, delta_z_guess]
+    bounds (list or None): custom bounds to overwrite the default option
+    return_dataframe (bool): If True, returns a pandas series of the output data
        instead of individual parameters
-   plotq (bool): If True, plots the fit and initial guess
+    plotq (bool): If True, plots the fit and initial guess
+    catch_exceptions (bool): If True, catches exceptions in the fitter and
+       returns nan values instead. Else, raises exceptions in the fitter
 
-   Returns:
-   p0 (list): initial guess parameters [fr0_guess, D_guess]
-   popt (list): fit parameters [fr0, D]
-   perr (list): fit parameter uncertainties [fr0_err, D_err]
-   (fig, ax): pyplot figure and axis, or (None, None) if not plotq
-   """
-   temperature, Q = np.array(temperature), np.array(Q)
-   fit_func = lambda a, b, c, d, e: Q_vs_temp_notls(a, b, c, d, e,
-                                                    gamma = gamma, N0 = N0)
+    Returns:
+    if return_dataframe is False:
+        p0 (list): initial guess parameters [fr0_guess, alpha_guess,
+                                             Tc_guess, delta_z_guess]
+        popt (list): fit parameters [fr0, alpha, Tc, delta_z]
+        perr (list): fit parameter uncertainties [fr0_err, alpha_err,
+                                                  Tc_err, delta_z_err]
+    else:
+        row (pd.Series): contains p0, popt, and perr
+    (fig, ax): pyplot figure and axis, or (None, None) if not plotq
+    """
+    T, Q = np.array(T), np.array(Q)
+    ix = np.argsort(T)
+    T, Q = T[ix], Q[ix]
+    if Q_err is not None:
+      Q_err = np.array(Q_err)[ix]
 
-   ix = np.argsort(temperature)
-   temperature, Q = temperature[ix], Q[ix]
-   if Q_err is not None:
-       Q_err = np.array(Q_err)[ix]
-   # Initial guess
-   if guess is not None:
+    fit_func = lambda a, b, c, d, e: Q_vs_T_qp(a, b, c, d, e, gamma = gamma)
+    # Initial guess
+    if guess is not None:
+      p0 = guess
+      bounds0 = get_bounds_Q_vs_T_qp(p0)
+    else:
+      p0, bounds0 = guess_p0_Q_vs_T_qp(T, Q, fr0_guess, Tc_guess, gamma)
+    if bounds is None:
+      bounds = bounds0
+    # Fit
+    if Q_err is None:
+      sigma = None
+      p00 = p0
+    else:
+      sigma = Q_err
+      try:
+         p00, _ = curve_fit(fit_func, T, Q, sigma = None,
+                             p0 = p0, bounds = bounds)
+         # To fit with sigma, the initial guess must be really good, so
+         # update the initial guess with curve_fit without sigma
+      except Exception as e:
+         if not catch_exceptions:
+             raise e
+         p00 = p0
+    try:
+      popt, pcov = curve_fit(fit_func, T, Q, sigma = sigma,
+                             p0 = p00, bounds = bounds, absolute_sigma = True)
+      perr = np.sqrt(np.diag(pcov))
+    except Exception as e:
+      if not catch_exceptions:
+          raise e
+      popt = [np.nan, np.nan, np.nan, np.nan]
+      perr = [np.nan, np.nan, np.nan, np.nan]
+    # Plot
+    if plotq:
+      fig, ax = plot_Q_vs_T_qp(T, Q, Q_err, popt, p0, gamma)
+    else:
+      fig, ax = None, None
+
+    if return_dataframe:
+      row = make_fit_row_Q_vs_T_qp(p0, popt, perr, gamma)
+      return row, (fig, ax)
+    return p0, popt, perr, (fig, ax)
+
+################################################################################
+########################### Resonance shift from TLS ###########################
+################################################################################
+def fit_f_vs_T_tls(T, f, f_err = None, guess = None,
+                       return_dataframe = False, plotq = False):
+    """
+    Fits resonance frequency versus temperature data to f_vs_T_tls
+
+    Parameters:
+    T (array-like): temperature data in K
+    f (array-like): resonance frequency data in Hz
+    f_err (array-like or None): If not None, f_err is the error on f used in
+        the fitting. If None, points are weighted equally
+    guess (list or None): If not None, overwrites the initial guess. Also
+        overwrites Tc_guess. [fr0_guess, Fdelta0_guess]
+    return_dataframe (bool): If True, returns a pandas series of the output data
+       instead of individual parameters
+    plotq (bool): If True, plots the fit and initial guess
+
+    Returns:
+    if return_dataframe is False:
+        p0 (list): initial guess parameters [fr0_guess, Fdelta0_guess]
+        popt (list): fit parameters [fr0, Fdelta0]
+        perr (list): fit parameter uncertainties [fr0_err, Fdelta0_err]
+    else:
+        row (pd.Series): contains p0, popt, and perr
+    (fig, ax): pyplot figure and axis, or (None, None) if not plotq
+    """
+    T, f = np.array(T), np.array(f)
+    ix = np.argsort(T)
+    T, f = T[ix], f[ix]
+    if f_err is not None:
+       f_err = np.array(f_err)[ix]
+
+    fit_func = lambda a, b, c: f_vs_T_tls(a, b, c)
+    # Initial guess
+    if guess is not None:
        p0 = guess
-       bounds = get_bounds_Q_vs_temp_notls(p0)
-   else:
-       alpha_guess = 0.7
-       p0, bounds = guess_p0_Q_vs_temp_notls(temperature, Q, fr0_guess,
-                                             alpha_guess = alpha_guess,
-                                             Tc_guess = Tc_guess,
-                                             gamma = gamma, N0 = N0)
-   # Fit
-   if Q_err is None:
+       bounds = get_bounds_f_vs_T_tls(p0)
+    else:
+       p0, bounds = guess_p0_f_vs_T_tls(T, f)
+    # Fit
+    if f_err is None:
        sigma = None
        p00 = p0
-   else:
+    else:
+       sigma = f_err
+       try:
+           p00, _ = curve_fit(fit_func, T, f, sigma = None, p0 = p0,
+                              bounds = bounds)
+          # To fit with sigma, the initial guess must be really good, so
+          # update the initial guess with curve_fit without sigma
+       except Exception as e:
+           if not catch_exceptions:
+               raise e
+           p00 = p0
+    try:
+       popt, pcov = curve_fit(fit_func, T, f, sigma = sigma, p0 = p00,
+                              bounds = bounds, absolute_sigma = True)
+       perr = np.sqrt(np.diag(pcov))
+    except Exception as e:
+        if not catch_exceptions:
+            raise e
+        popt = [np.nan, np.nan]
+        perr = [np.nan, np.nan]
+    # Plot
+    if plotq:
+       fig, ax = plot_f_vs_T_tls(T, f, f_err, popt, p0)
+    else:
+       fig, ax = None, None
+
+    if return_dataframe:
+       row = make_fit_row_f_vs_T_tls(p0, popt, perr)
+       return row, (fig, ax)
+    return p0, popt, perr, (fig, ax)
+
+def fit_Q_vs_T_tls(T, Q, fr0_guess, Q_err = None,  guess = None,
+                       return_dataframe = False, plotq = False):
+    """
+    Fits resonance frequency versus temperature data to Q_vs_T_tls
+
+    Parameters:
+    T (array-like): temperature data in K
+    Q (array-like): quality factor data
+    Q_err (array-like or None): If not None, fr_err is the error on Q used in
+        the fitting. If None, points are weighted equally
+    fr0_guess (float): guess for the resonant frequency in Hz at T = 0 K
+    guess (list or None): If not None, overwrites the initial guess. Also
+        overwrites Tc_guess. [fr0_guess, Fdelta0_guess]
+    return_dataframe (bool): If True, returns a pandas series of the output data
+       instead of individual parameters
+    plotq (bool): If True, plots the fit and initial guess
+
+    Returns:
+    if return_dataframe is False:
+        p0 (list): initial guess parameters [fr0_guess, Fdelta0_guess,
+                                             delta_z_guess]
+        popt (list): fit parameters [fr0, Fdelta0, delta_z]
+        perr (list): fit parameter uncertainties [fr0_err, Fdelta0_err,
+                                                  delta_z_err]
+    else:
+        row (pd.Series): contains p0, popt, and perr
+    (fig, ax): pyplot figure and axis, or (None, None) if not plotq
+    """
+    T, Q = np.array(T), np.array(Q)
+    ix = np.argsort(T)
+    T, Q = T[ix], Q[ix]
+    if Q_err is not None:
+       Q_err = np.array(Q_err)[ix]
+
+    fit_func = lambda a, b, c, d: Q_vs_T_tls(a, b, c, d)
+    # Initial guess
+    if guess is not None:
+       p0 = guess
+       bounds = get_bounds_Q_vs_T_tls(p0)
+    else:
+       p0, bounds = guess_p0_Q_vs_T_tls(T, Q, fr0_guess)
+    # Fit
+    if Q_err is None:
+       sigma = None
+       p00 = p0
+    else:
        sigma = Q_err
        try:
-           p00, _ = curve_fit(fit_func, temperature, Q, sigma = None,
-                              p0 = p0, bounds = bounds)
+           p00, _ = curve_fit(fit_func, T, Q, sigma = None, p0 = p0,
+                              bounds = bounds)
           # To fit with sigma, the initial guess must be really good, so
           # update the initial guess with curve_fit without sigma
-       except:
+       except Exception as e:
+           if not catch_exceptions:
+               raise e
            p00 = p0
-   try:
-       popt, pcov = curve_fit(fit_func, temperature, Q, sigma = sigma,
-                              p0 = p00, bounds = bounds, absolute_sigma = True)
+    try:
+       popt, pcov = curve_fit(fit_func, T, Q, sigma = sigma, p0 = p00,
+                              bounds = bounds, absolute_sigma = True)
        perr = np.sqrt(np.diag(pcov))
-   except Exception as e:
-       raise e
-       popt = [np.nan, np.nan, np.nan]
-       perr = [np.nan, np.nan, np.nan]
-   # Plot
-   if plotq:
-       fig, ax = plot_Q_vs_temp_notls(temperature, Q, Q_err, popt, p0, gamma, N0)
-   else:
+    except Exception as e:
+        if not catch_exceptions:
+            raise e
+        popt = [np.nan, np.nan, np.nan]
+        perr = [np.nan, np.nan, np.nan]
+    # Plot
+    if plotq:
+       fig, ax = plot_Q_vs_T_tls(T, Q, Q_err, popt, p0)
+    else:
        fig, ax = None, None
 
-   if return_dataframe:
-       row = make_fit_row_Q_vs_temp_notls(p0, popt, perr, gamma, N0)
+    if return_dataframe:
+       row = make_fit_row_Q_vs_T_tls(p0, popt, perr)
        return row, (fig, ax)
-   return p0, popt, perr, gamma, N0, (fig, ax)
-
-################################################################################
-######################## Funcs with only TLS component #########################
-################################################################################
-def fit_fr_vs_temp_tls(temperature, fr, fr_err = None, guess = None,
-                       return_dataframe = False, plotq = False):
-   """
-   Fits resonance frequency versus temperature data to fr_vs_temp_tls
-
-   Parameters:
-   temperature (array-like): temperature data in K
-   fr (array-like): resonance frequency data in Hz
-   fr_err (array-like or None): If not None, fr_err is the error on fr used in
-        the fitting. If None, points are weighted equally
-   guess (list or None): If not None, overwrites the initial guess. Also
-        overwrites Tc_guess. [fr0_guess, D_guess]
-   return_dataframe (bool): If True, returns a pandas series of the output data
-       instead of individual parameters
-   plotq (bool): If True, plots the fit and initial guess
-
-   Returns:
-   p0 (list): initial guess parameters [fr0_guess, D_guess]
-   popt (list): fit parameters [fr0, D]
-   perr (list): fit parameter uncertainties [fr0_err, D_err]
-   (fig, ax): pyplot figure and axis, or (None, None) if not plotq
-   """
-   temperature, fr = np.array(temperature), np.array(fr)
-   fit_func = lambda a, b, c: fr_vs_temp_tls(a, b, c)
-
-   ix = np.argsort(temperature)
-   temperature, fr = temperature[ix], fr[ix]
-   if fr_err is not None:
-       fr_err = np.array(fr_err)[ix]
-   # Initial guess
-   if guess is not None:
-       p0 = guess
-       bounds = get_bounds_fr_vs_temp_tls(p0)
-   else:
-       p0, bounds = guess_p0_fr_vs_temp_tls(temperature, fr)
-   # Fit
-   if fr_err is None:
-       sigma = None
-       p00 = p0
-   else:
-       sigma = fr_err
-       try:
-           p00, _ = curve_fit(fit_func, temperature, fr, sigma = None,
-                              p0 = p0, bounds = bounds)
-          # To fit with sigma, the initial guess must be really good, so
-          # update the initial guess with curve_fit without sigma
-       except:
-           p00 = p0
-   try:
-       popt, pcov = curve_fit(fit_func, temperature, fr, sigma = sigma,
-                              p0 = p00, bounds = bounds, absolute_sigma = True)
-       perr = np.sqrt(np.diag(pcov))
-   except Exception as e:
-       popt = [np.nan, np.nan]
-       perr = [np.nan, np.nan]
-   # Plot
-   if plotq:
-       fig, ax = plot_fr_vs_temp_tls(temperature, fr, fr_err, popt, p0)
-   else:
-       fig, ax = None, None
-
-   if return_dataframe:
-       row = make_fit_row_fr_vs_temp_tls(p0, popt, perr)
-       return row, (fig, ax)
-   return p0, popt, perr, (fig, ax)
+    return p0, popt, perr, (fig, ax)

--- a/citkid/res_vs_temp/fitter.py
+++ b/citkid/res_vs_temp/fitter.py
@@ -8,108 +8,21 @@ from .data_io import *
 ################################################################################
 ############### Resonance shift from thermal QP density and TLS ################
 ################################################################################
-def fit_f_vs_T(temperature, fr, gamma = 1, Tc_guess = 1.3, fr_err = None,
-                   guess = None, enforced_alpha = None,
-                   return_dataframe = False, plotq = False):
-   """
-   Fits resonance frequency versus temperature data to f_vs_T
-
-   Parameters:
-   temperature (array-like): temperature data in K
-   fr (array-like): resonance frequency data in Hz
-   gamma (float): 1, 1/2, or 1/3 for thin-film, local, or anomalous limits
-   Tc_guess (float): guess for the critical temperature
-   fr_err (array-like or None): If not None, fr_err is the error on fr used in
-        the fitting. If None, points are weighted equally
-   guess (list or None): If not None, overwrites the initial guess. Also
-        overwrites Tc_guess. [fr0_guess, D_guess, alpha_guess, Tc_guess]
-    enforced_alpha (float or None): if float, enforces alpha to be this value
-        instead of fitting. If None, fits for alpha
-   return_dataframe (bool): if True, returns a pandas series of the output data
-       instead of individual parameters
-   plotq (bool): If True, plots the fit and initial guess
-
-   Returns:
-   p0 (list): initial guess parameters
-        [fr0_guess, D_guess, alpha_guess, Tc_guess]
-   popt (list): fit parameters [fr0, D, alpha, Tc]
-   perr (list): fit parameter uncertainties [fr0_err, D_err, alpha_err, Tc_err]
-   (fig, ax): pyplot figure and axis, or (None, None) if not plotq
-   """
-   temperature, fr = np.array(temperature), np.array(fr)
-   if enforced_alpha is not None:
-       fit_func = lambda a, b, c, e: f_vs_T(a, b, c, enforced_alpha, e,
-                                                gamma = gamma)
-   else:
-       fit_func = lambda a, b, c, d, e: f_vs_T(a, b, c, d, e, gamma = gamma)
-
-   ix = np.argsort(temperature)
-   temperature, fr = temperature[ix], fr[ix]
-   if fr_err is not None:
-       fr_err = np.array(fr_err)[ix]
-   # Initial guess
-   if guess is not None:
-       p0 = guess
-       bounds = get_bounds_f_vs_T(p0)
-   else:
-       p0, bounds = guess_p0_f_vs_T(temperature, fr, Tc_guess, gamma)
-   if enforced_alpha is not None:
-       p0 = np.append(p0[:2], p0[3])
-       bounds[0] = np.append(bounds[0][:2], bounds[0][3])
-       bounds[1] = np.append(bounds[1][:2], bounds[1][3])
-   # Fit
-   if fr_err is None:
-       sigma = None
-       p00 = p0
-   else:
-       sigma = fr_err
-       try:
-           p00, _ = curve_fit(fit_func, temperature, fr, sigma = None,
-                              p0 = p0, bounds = bounds)
-          # To fit with sigma, the initial guess must be really good, so
-          # update the initial guess with curve_fit without sigma
-       except:
-           p00 = p0
-   try:
-       popt, pcov = curve_fit(fit_func, temperature, fr, sigma = sigma,
-                              p0 = p00, bounds = bounds, absolute_sigma = True)
-       perr = np.sqrt(np.diag(pcov))
-   except Exception as e:
-       popt = [np.nan, np.nan, np.nan, np.nan]
-       perr = [np.nan, np.nan, np.nan, np.nan]
-   if enforced_alpha is not None:
-       p0 = np.append(np.append(p0[:2], enforced_alpha), p0[2])
-       popt = np.append(np.append(popt[:2], enforced_alpha), popt[2])
-       perr = np.append(np.append(perr[:2],enforced_alpha), perr[2])
-   # Plot
-   if plotq:
-       fig, ax = plot_f_vs_T(temperature, fr, fr_err, popt, p0, gamma)
-   else:
-       fig, ax = None, None
-
-   if return_dataframe:
-       row = make_fit_row_f_vs_T(p0, popt, perr, gamma)
-       return row, (fig, ax)
-   return p0, popt, perr, (fig, ax)
-
-################################################################################
-################### Resonance shift from thermal QP density ####################
-################################################################################
-def fit_f_vs_T_qp(T, f, gamma = 1, Tc_guess = 1.2, f_err = None, guess = None,
-                  bounds = None, return_dataframe = False, plotq = False,
-                  catch_exceptions = False):
+def fit_f_vs_T(T, f, gamma = 1, Tc_guess = 1.2, f_err = None, guess = None,
+               bounds = None, return_dataframe = False, plotq = False,
+               catch_exceptions = False):
     """
-    Fits resonance frequency versus temperature data to f_vs_T_qp.
+    Fits resonant frequency versus temperature data to f_vs_T.
 
     Parameters:
     T (array-like): temperature data in K
-    f (array-like): resonance frequency data in Hz
+    f (array-like): resonant frequency data in Hz
     gamma (float): 1, 1/2, or 1/3 for thin-film, local, or anomalous limits
-    Tc_guess (float): guess for the critical temperature
+    Tc_guess (float): critical temperature guess in K
     f_err (array-like or None): If not None, f_err is the error on f used in
         the fitting. If None, points are weighted equally
     guess (list or None): If not None, overwrites the initial guess. Also
-        overwrites Tc_guess. [fr0_guess, alpha_guess, Tc_guess]
+        overwrites Tc_guess.
     bounds (list or None): custom bounds to overwrite the default option
     return_dataframe (bool): If True, returns a pandas series of the output data
        instead of individual parameters
@@ -119,9 +32,184 @@ def fit_f_vs_T_qp(T, f, gamma = 1, Tc_guess = 1.2, f_err = None, guess = None,
 
     Returns:
     if return_dataframe is False:
-        p0 (list): initial guess parameters [fr0_guess, alpha_guess, Tc_guess]
-        popt (list): fit parameters [fr0, alpha, Tc]
-        perr (list): fit parameter uncertainties [fr0_err, alpha_err, Tc_err]
+        p0 (list): initial guess parameters [f0_guess, alpha_guess,
+                                             Tc_guess, Fdelta0_guess]
+        popt (list): fit parameters [f0, alpha, Tc, Fdelta0]
+        perr (list): fit parameter uncertainties [f0_err, alpha_err,
+                                                  Tc_err, Fdelta0_err]
+    else:
+        row (pd.Series): contains p0, popt, and perr
+    (fig, ax): pyplot figure and axis, or (None, None) if not plotq
+    """
+    T, f = np.array(T), np.array(f)
+    ix = np.argsort(T)
+    T, f = T[ix], f[ix]
+    if f_err is not None:
+       f_err = np.array(f_err)[ix]
+
+    fit_func = lambda a, b, c, d, e: f_vs_T(a, b, c, d, e, gamma = gamma)
+    # Initial guess
+    if guess is not None:
+       p0 = guess
+       bounds_qp, bounds_tls = get_bounds_f_vs_T_qp(p0), get_bounds_f_vs_T_tls(p0)
+       bounds0 = get_bounds_f_vs_T(bounds_qp, bounds_tls)
+    else:
+       p0, bounds0 = guess_p0_f_vs_T(T, f, Tc_guess, gamma)
+    if bounds is None:
+       bounds = bounds0
+    # Fit
+    if f_err is None:
+       sigma = None
+       p00 = p0
+    else:
+       sigma = f_err
+       try:
+          p00, _ = curve_fit(fit_func, T, f, sigma = None,
+                              p0 = p0, bounds = bounds)
+          # To fit with sigma, the initial guess must be really good, so
+          # update the initial guess with curve_fit without sigma
+       except Exception as e:
+          if not catch_exceptions:
+              raise e
+          p00 = p0
+    try:
+       popt, pcov = curve_fit(fit_func, T, f, sigma = sigma,
+                              p0 = p00, bounds = bounds, absolute_sigma = True)
+       perr = np.sqrt(np.diag(pcov))
+    except Exception as e:
+       if not catch_exceptions:
+           raise e
+       popt = [np.nan, np.nan, np.nan, np.nan]
+       perr = [np.nan, np.nan, np.nan, np.nan]
+    # Plot
+    if plotq:
+       fig, ax = plot_f_vs_T(T, f, f_err, popt, p0, gamma)
+    else:
+       fig, ax = None, None
+
+    if return_dataframe:
+       row = make_fit_row_f_vs_T(p0, popt, perr, gamma)
+       return row, (fig, ax)
+    return p0, popt, perr, (fig, ax)
+
+def fit_Q_vs_T(T, Q, f0_guess, gamma = 1, Tc_guess = 1.2, Q_err = None,
+               guess = None, bounds = None, return_dataframe = False,
+               plotq = False, catch_exceptions = False):
+    """
+    Fits quality factor versus temperature data to Q_vs_T.
+
+    Parameters:
+    T (array-like): temperature data in K
+    Q (array-like): quality factor data
+    f0_guess (float): guess for the resonant frequency in Hz at T = 0 K
+    gamma (float): 1, 1/2, or 1/3 for thin-film, local, or anomalous limits
+    Tc_guess (float): critical temperature guess in K
+    Q_err (array-like or None): If not None, Q_err is the error on Q used in
+        the fitting. If None, points are weighted equally
+    guess (list or None): If not None, overwrites the initial guess. Also
+        overwrites f0_guess.
+    bounds (list or None): custom bounds to overwrite the default option
+    return_dataframe (bool): If True, returns a pandas series of the output data
+       instead of individual parameters
+    plotq (bool): If True, plots the fit and initial guess
+    catch_exceptions (bool): If True, catches exceptions in the fitter and
+       returns nan values instead. Else, raises exceptions in the fitter
+
+    Returns:
+    if return_dataframe is False:
+        p0 (list): initial guess parameters [f0_guess, alpha_guess,
+                                             Tc_guess, Fdelta0_guess,
+                                             delta_z_guess]
+        popt (list): fit parameters [f0, alpha, Tc, Fdelta0, delta_z]
+        perr (list): fit parameter uncertainties [f0_err, alpha_err,
+                                                  Tc_err, Fdelta0_err,
+                                                  delta_z_err]
+    else:
+        row (pd.Series): contains p0, popt, and perr
+    (fig, ax): pyplot figure and axis, or (None, None) if not plotq
+    """
+    T, Q = np.array(T), np.array(Q)
+    ix = np.argsort(T)
+    T, Q = T[ix], Q[ix]
+    if Q_err is not None:
+      Q_err = np.array(Q_err)[ix]
+
+    fit_func = lambda a, b, c, d, e, f: Q_vs_T(a, b, c, d, e, f,
+                                                  gamma = gamma)
+    # Initial guess
+    if guess is not None:
+        p0 = guess
+        bounds_qp, bounds_tls = get_bounds_Q_vs_T_qp(p0), get_bounds_Q_vs_T_tls(p0)
+        bounds0 = get_bounds_Q_vs_T(bounds_qp, bounds_tls)
+    else:
+          p0, bounds0 = guess_p0_Q_vs_T(T, Q, f0_guess, Tc_guess, gamma)
+    if bounds is None:
+        bounds = bounds0
+    # Fit
+    if Q_err is None:
+        sigma = None
+        p00 = p0
+    else:
+      sigma = Q_err
+      try:
+         p00, _ = curve_fit(fit_func, T, Q, sigma = None,
+                             p0 = p0, bounds = bounds)
+         # To fit with sigma, the initial guess must be really good, so
+         # update the initial guess with curve_fit without sigma
+      except Exception as e:
+         if not catch_exceptions:
+             raise e
+         p00 = p0
+    try:
+      popt, pcov = curve_fit(fit_func, T, Q, sigma = sigma,
+                             p0 = p00, bounds = bounds, absolute_sigma = True)
+      perr = np.sqrt(np.diag(pcov))
+    except Exception as e:
+      if not catch_exceptions:
+          raise e
+      popt = [np.nan, np.nan, np.nan, np.nan, np.nan]
+      perr = [np.nan, np.nan, np.nan, np.nan, np.nan]
+    # Plot
+    if plotq:
+      fig, ax = plot_Q_vs_T(T, Q, Q_err, popt, p0, gamma)
+    else:
+      fig, ax = None, None
+
+    if return_dataframe:
+      row = make_fit_row_Q_vs_T(p0, popt, perr, gamma)
+      return row, (fig, ax)
+    return p0, popt, perr, (fig, ax)
+
+################################################################################
+################### Resonance shift from thermal QP density ####################
+################################################################################
+def fit_f_vs_T_qp(T, f, gamma = 1, Tc_guess = 1.2, f_err = None, guess = None,
+                  bounds = None, return_dataframe = False, plotq = False,
+                  catch_exceptions = False):
+    """
+    Fits resonant frequency versus temperature data to f_vs_T_qp.
+
+    Parameters:
+    T (array-like): temperature data in K
+    f (array-like): resonant frequency data in Hz
+    gamma (float): 1, 1/2, or 1/3 for thin-film, local, or anomalous limits
+    Tc_guess (float): critical temperature guess in K
+    f_err (array-like or None): If not None, f_err is the error on f used in
+        the fitting. If None, points are weighted equally
+    guess (list or None): If not None, overwrites the initial guess. Also
+        overwrites Tc_guess.
+    bounds (list or None): custom bounds to overwrite the default option
+    return_dataframe (bool): If True, returns a pandas series of the output data
+       instead of individual parameters
+    plotq (bool): If True, plots the fit and initial guess
+    catch_exceptions (bool): If True, catches exceptions in the fitter and
+       returns nan values instead. Else, raises exceptions in the fitter
+
+    Returns:
+    if return_dataframe is False:
+        p0 (list): initial guess parameters [f0_guess, alpha_guess, Tc_guess]
+        popt (list): fit parameters [f0, alpha, Tc]
+        perr (list): fit parameter uncertainties [f0_err, alpha_err, Tc_err]
     else:
         row (pd.Series): contains p0, popt, and perr
     (fig, ax): pyplot figure and axis, or (None, None) if not plotq
@@ -176,21 +264,22 @@ def fit_f_vs_T_qp(T, f, gamma = 1, Tc_guess = 1.2, f_err = None, guess = None,
        return row, (fig, ax)
     return p0, popt, perr, (fig, ax)
 
-def fit_Q_vs_T_qp(T, Q, fr0_guess, gamma = 1, Tc_guess = 1.2, Q_err = None,
+def fit_Q_vs_T_qp(T, Q, f0_guess, gamma = 1, Tc_guess = 1.2, Q_err = None,
                   guess = None, bounds = None, return_dataframe = False,
                   plotq = False, catch_exceptions = False):
     """
-    Fits quality factor versus temperature to Q_vs_T_qp
+    Fits quality factor versus temperature data to Q_vs_T_qp.
 
     Parameters:
     T (array-like): temperature data in K
     Q (array-like): quality factor data
-    fr0_guess (float): guess for the resonant frequency in Hz at T = 0 K
+    f0_guess (float): guess for the resonant frequency in Hz at T = 0 K
+    gamma (float): 1, 1/2, or 1/3 for thin-film, local, or anomalous limits
+    Tc_guess (float): critical temperature guess in K
     Q_err (array-like or None): If not None, Q_err is the error on Q used in
         the fitting. If None, points are weighted equally
-    gamma (float): 1, 1/2, or 1/3 for thin-film, local, or anomalous limits
     guess (list or None): If not None, overwrites the initial guess. Also
-        overwrites fr0_guess. [fr0_guess, alpha_guess, Tc_guess, delta_z_guess]
+        overwrites f0_guess.
     bounds (list or None): custom bounds to overwrite the default option
     return_dataframe (bool): If True, returns a pandas series of the output data
        instead of individual parameters
@@ -200,10 +289,10 @@ def fit_Q_vs_T_qp(T, Q, fr0_guess, gamma = 1, Tc_guess = 1.2, Q_err = None,
 
     Returns:
     if return_dataframe is False:
-        p0 (list): initial guess parameters [fr0_guess, alpha_guess,
+        p0 (list): initial guess parameters [f0_guess, alpha_guess,
                                              Tc_guess, delta_z_guess]
-        popt (list): fit parameters [fr0, alpha, Tc, delta_z]
-        perr (list): fit parameter uncertainties [fr0_err, alpha_err,
+        popt (list): fit parameters [f0, alpha, Tc, delta_z]
+        perr (list): fit parameter uncertainties [f0_err, alpha_err,
                                                   Tc_err, delta_z_err]
     else:
         row (pd.Series): contains p0, popt, and perr
@@ -213,76 +302,80 @@ def fit_Q_vs_T_qp(T, Q, fr0_guess, gamma = 1, Tc_guess = 1.2, Q_err = None,
     ix = np.argsort(T)
     T, Q = T[ix], Q[ix]
     if Q_err is not None:
-      Q_err = np.array(Q_err)[ix]
+        Q_err = np.array(Q_err)[ix]
 
     fit_func = lambda a, b, c, d, e: Q_vs_T_qp(a, b, c, d, e, gamma = gamma)
     # Initial guess
     if guess is not None:
-      p0 = guess
-      bounds0 = get_bounds_Q_vs_T_qp(p0)
+        p0 = guess
+        bounds0 = get_bounds_Q_vs_T_qp(p0)
     else:
-      p0, bounds0 = guess_p0_Q_vs_T_qp(T, Q, fr0_guess, Tc_guess, gamma)
+        p0, bounds0 = guess_p0_Q_vs_T_qp(T, Q, f0_guess, Tc_guess, gamma)
     if bounds is None:
-      bounds = bounds0
+        bounds = bounds0
     # Fit
     if Q_err is None:
-      sigma = None
-      p00 = p0
+        sigma = None
+        p00 = p0
     else:
-      sigma = Q_err
-      try:
-         p00, _ = curve_fit(fit_func, T, Q, sigma = None,
+        sigma = Q_err
+        try:
+            p00, _ = curve_fit(fit_func, T, Q, sigma = None,
                              p0 = p0, bounds = bounds)
-         # To fit with sigma, the initial guess must be really good, so
-         # update the initial guess with curve_fit without sigma
-      except Exception as e:
-         if not catch_exceptions:
-             raise e
+            # To fit with sigma, the initial guess must be really good, so
+            # update the initial guess with curve_fit without sigma
+        except Exception as e:
+            if not catch_exceptions:
+                raise e
          p00 = p0
     try:
-      popt, pcov = curve_fit(fit_func, T, Q, sigma = sigma,
+        popt, pcov = curve_fit(fit_func, T, Q, sigma = sigma,
                              p0 = p00, bounds = bounds, absolute_sigma = True)
-      perr = np.sqrt(np.diag(pcov))
+        perr = np.sqrt(np.diag(pcov))
     except Exception as e:
-      if not catch_exceptions:
-          raise e
-      popt = [np.nan, np.nan, np.nan, np.nan]
-      perr = [np.nan, np.nan, np.nan, np.nan]
+        if not catch_exceptions:
+            raise e
+        popt = [np.nan, np.nan, np.nan, np.nan]
+        perr = [np.nan, np.nan, np.nan, np.nan]
     # Plot
     if plotq:
-      fig, ax = plot_Q_vs_T_qp(T, Q, Q_err, popt, p0, gamma)
+        fig, ax = plot_Q_vs_T_qp(T, Q, Q_err, popt, p0, gamma)
     else:
-      fig, ax = None, None
+        fig, ax = None, None
 
     if return_dataframe:
-      row = make_fit_row_Q_vs_T_qp(p0, popt, perr, gamma)
-      return row, (fig, ax)
+        row = make_fit_row_Q_vs_T_qp(p0, popt, perr, gamma)
+        return row, (fig, ax)
     return p0, popt, perr, (fig, ax)
 
 ################################################################################
 ########################### Resonance shift from TLS ###########################
 ################################################################################
-def fit_f_vs_T_tls(T, f, f_err = None, guess = None,
-                       return_dataframe = False, plotq = False):
+def fit_f_vs_T_tls(T, f, f_err = None, guess = None, bounds = None,
+                   return_dataframe = False, plotq = False,
+                   catch_exceptions = False):
     """
-    Fits resonance frequency versus temperature data to f_vs_T_tls
+    Fits resonant frequency versus temperature data to f_vs_T_tls.
 
     Parameters:
     T (array-like): temperature data in K
-    f (array-like): resonance frequency data in Hz
+    f (array-like): resonant frequency data in Hz
     f_err (array-like or None): If not None, f_err is the error on f used in
         the fitting. If None, points are weighted equally
     guess (list or None): If not None, overwrites the initial guess. Also
-        overwrites Tc_guess. [fr0_guess, Fdelta0_guess]
+        overwrites Tc_guess.
+    bounds (list or None): custom bounds to overwrite the default option
     return_dataframe (bool): If True, returns a pandas series of the output data
        instead of individual parameters
     plotq (bool): If True, plots the fit and initial guess
+    catch_exceptions (bool): If True, catches exceptions in the fitter and
+       returns nan values instead. Else, raises exceptions in the fitter
 
     Returns:
     if return_dataframe is False:
-        p0 (list): initial guess parameters [fr0_guess, Fdelta0_guess]
-        popt (list): fit parameters [fr0, Fdelta0]
-        perr (list): fit parameter uncertainties [fr0_err, Fdelta0_err]
+        p0 (list): initial guess parameters [f0_guess, Fdelta0_guess]
+        popt (list): fit parameters [f0, Fdelta0]
+        perr (list): fit parameter uncertainties [f0_err, Fdelta0_err]
     else:
         row (pd.Series): contains p0, popt, and perr
     (fig, ax): pyplot figure and axis, or (None, None) if not plotq
@@ -297,9 +390,11 @@ def fit_f_vs_T_tls(T, f, f_err = None, guess = None,
     # Initial guess
     if guess is not None:
        p0 = guess
-       bounds = get_bounds_f_vs_T_tls(p0)
+       bounds0 = get_bounds_f_vs_T_tls(p0)
     else:
-       p0, bounds = guess_p0_f_vs_T_tls(T, f)
+       p0, bounds0 = guess_p0_f_vs_T_tls(T, f)
+    if bounds is None:
+        bounds = bounds0
     # Fit
     if f_err is None:
        sigma = None
@@ -335,29 +430,33 @@ def fit_f_vs_T_tls(T, f, f_err = None, guess = None,
        return row, (fig, ax)
     return p0, popt, perr, (fig, ax)
 
-def fit_Q_vs_T_tls(T, Q, fr0_guess, Q_err = None,  guess = None,
-                       return_dataframe = False, plotq = False):
+def fit_Q_vs_T_tls(T, Q, f0_guess, Q_err = None,  guess = None, bounds = None,
+                   return_dataframe = False, plotq = False,
+                   catch_exceptions = False):
     """
-    Fits resonance frequency versus temperature data to Q_vs_T_tls
+    Fits resonant frequency versus temperature data to Q_vs_T_tls.
 
     Parameters:
     T (array-like): temperature data in K
     Q (array-like): quality factor data
     Q_err (array-like or None): If not None, fr_err is the error on Q used in
         the fitting. If None, points are weighted equally
-    fr0_guess (float): guess for the resonant frequency in Hz at T = 0 K
+    f0_guess (float): guess for the resonant frequency in Hz at T = 0 K
     guess (list or None): If not None, overwrites the initial guess. Also
-        overwrites Tc_guess. [fr0_guess, Fdelta0_guess]
+        overwrites Tc_guess.
+    bounds (list or None): custom bounds to overwrite the default option
     return_dataframe (bool): If True, returns a pandas series of the output data
        instead of individual parameters
     plotq (bool): If True, plots the fit and initial guess
+    catch_exceptions (bool): If True, catches exceptions in the fitter and
+       returns nan values instead. Else, raises exceptions in the fitter
 
     Returns:
     if return_dataframe is False:
-        p0 (list): initial guess parameters [fr0_guess, Fdelta0_guess,
+        p0 (list): initial guess parameters [f0_guess, Fdelta0_guess,
                                              delta_z_guess]
-        popt (list): fit parameters [fr0, Fdelta0, delta_z]
-        perr (list): fit parameter uncertainties [fr0_err, Fdelta0_err,
+        popt (list): fit parameters [f0, Fdelta0, delta_z]
+        perr (list): fit parameter uncertainties [f0_err, Fdelta0_err,
                                                   delta_z_err]
     else:
         row (pd.Series): contains p0, popt, and perr
@@ -367,34 +466,36 @@ def fit_Q_vs_T_tls(T, Q, fr0_guess, Q_err = None,  guess = None,
     ix = np.argsort(T)
     T, Q = T[ix], Q[ix]
     if Q_err is not None:
-       Q_err = np.array(Q_err)[ix]
+        Q_err = np.array(Q_err)[ix]
 
     fit_func = lambda a, b, c, d: Q_vs_T_tls(a, b, c, d)
     # Initial guess
     if guess is not None:
-       p0 = guess
-       bounds = get_bounds_Q_vs_T_tls(p0)
+        p0 = guess
+        bounds = get_bounds_Q_vs_T_tls(p0)
     else:
-       p0, bounds = guess_p0_Q_vs_T_tls(T, Q, fr0_guess)
+        p0, bounds = guess_p0_Q_vs_T_tls(T, Q, f0_guess)
+    if bounds is None:
+        bounds = bounds0
     # Fit
     if Q_err is None:
        sigma = None
        p00 = p0
     else:
-       sigma = Q_err
-       try:
-           p00, _ = curve_fit(fit_func, T, Q, sigma = None, p0 = p0,
+        sigma = Q_err
+        try:
+            p00, _ = curve_fit(fit_func, T, Q, sigma = None, p0 = p0,
                               bounds = bounds)
-          # To fit with sigma, the initial guess must be really good, so
-          # update the initial guess with curve_fit without sigma
-       except Exception as e:
-           if not catch_exceptions:
+            # To fit with sigma, the initial guess must be really good, so
+            # update the initial guess with curve_fit without sigma
+        except Exception as e:
+            if not catch_exceptions:
                raise e
-           p00 = p0
+            p00 = p0
     try:
-       popt, pcov = curve_fit(fit_func, T, Q, sigma = sigma, p0 = p00,
+        popt, pcov = curve_fit(fit_func, T, Q, sigma = sigma, p0 = p00,
                               bounds = bounds, absolute_sigma = True)
-       perr = np.sqrt(np.diag(pcov))
+        perr = np.sqrt(np.diag(pcov))
     except Exception as e:
         if not catch_exceptions:
             raise e

--- a/citkid/res_vs_temp/fitter.py
+++ b/citkid/res_vs_temp/fitter.py
@@ -8,8 +8,9 @@ from .data_io import *
 ################################################################################
 ############### Resonance shift from thermal QP density and TLS ################
 ################################################################################
-def fit_f_vs_T(T, f, gamma = 1, Tc_guess = 1.2, f_err = None, guess = None,
-               bounds = None, return_dataframe = False, plotq = False,
+def fit_f_vs_T(T, f, gamma = 1, Tc_guess = 1.2, enforced_alpha = None,
+               f_err = None, guess = None, bounds = None,
+               return_dataframe = False, plotq = False,
                catch_exceptions = False):
     """
     Fits resonant frequency versus temperature data to f_vs_T.
@@ -21,6 +22,8 @@ def fit_f_vs_T(T, f, gamma = 1, Tc_guess = 1.2, f_err = None, guess = None,
     Tc_guess (float): critical temperature guess in K
     f_err (array-like or None): If not None, f_err is the error on f used in
         the fitting. If None, points are weighted equally
+    enforced_alpha (float or None): if not None, enforces alpha to be this
+        value. Else fits for alpha
     guess (list or None): If not None, overwrites the initial guess. Also
         overwrites Tc_guess.
     bounds (list or None): custom bounds to overwrite the default option
@@ -45,56 +48,72 @@ def fit_f_vs_T(T, f, gamma = 1, Tc_guess = 1.2, f_err = None, guess = None,
     ix = np.argsort(T)
     T, f = T[ix], f[ix]
     if f_err is not None:
-       f_err = np.array(f_err)[ix]
+        f_err = np.array(f_err)[ix]
 
-    fit_func = lambda a, b, c, d, e: f_vs_T(a, b, c, d, e, gamma = gamma)
+    if enforced_alpha is None:
+        fit_func = lambda a, b, c, d, e: f_vs_T(a, b, c, d, e, gamma = gamma)
+    else:
+        fit_func = lambda a, b, d, e: f_vs_T(a, b, enforced_alpha, d, e,
+                                             gamma = gamma)
     # Initial guess
     if guess is not None:
-       p0 = guess
-       bounds_qp, bounds_tls = get_bounds_f_vs_T_qp(p0), get_bounds_f_vs_T_tls(p0)
-       bounds0 = get_bounds_f_vs_T(bounds_qp, bounds_tls)
+        p0 = list(guess)
+        bounds_qp = get_bounds_f_vs_T_qp(p0[:3])
+        bounds_tls = get_bounds_f_vs_T_tls([p0[0], p0[3]])
+        bounds0 = get_bounds_f_vs_T(bounds_qp, bounds_tls)
     else:
-       p0, bounds0 = guess_p0_f_vs_T(T, f, Tc_guess, gamma)
+        p0, bounds0 = guess_p0_f_vs_T(T, f, Tc_guess, gamma)
     if bounds is None:
-       bounds = bounds0
+        bounds = bounds0
+    p0, bounds = p0[:], [b[:] for b in bounds]
+    if enforced_alpha is not None:
+        p0.pop(1)
+        bounds[0].pop(1)
+        bounds[1].pop(1)
     # Fit
     if f_err is None:
-       sigma = None
-       p00 = p0
+        sigma = None
+        p00 = p0
     else:
-       sigma = f_err
-       try:
-          p00, _ = curve_fit(fit_func, T, f, sigma = None,
+        sigma = f_err
+        try:
+            p00, _ = curve_fit(fit_func, T, f, sigma = None,
                               p0 = p0, bounds = bounds)
-          # To fit with sigma, the initial guess must be really good, so
-          # update the initial guess with curve_fit without sigma
-       except Exception as e:
-          if not catch_exceptions:
-              raise e
-          p00 = p0
+            # To fit with sigma, the initial guess must be really good, so
+            # update the initial guess with curve_fit without sigma
+        except Exception as e:
+            if not catch_exceptions:
+                raise e
+            p00 = p0
     try:
-       popt, pcov = curve_fit(fit_func, T, f, sigma = sigma,
+        popt, pcov = curve_fit(fit_func, T, f, sigma = sigma,
                               p0 = p00, bounds = bounds, absolute_sigma = True)
-       perr = np.sqrt(np.diag(pcov))
+        perr = np.sqrt(np.diag(pcov))
     except Exception as e:
-       if not catch_exceptions:
-           raise e
-       popt = [np.nan, np.nan, np.nan, np.nan]
-       perr = [np.nan, np.nan, np.nan, np.nan]
+        if not catch_exceptions:
+            raise e
+        popt = [np.nan, np.nan, np.nan, np.nan]
+        perr = [np.nan, np.nan, np.nan, np.nan]
+    popt, perr = list(popt), list(perr)
+    if enforced_alpha is not None and np.isfinite(popt[0]):
+        p0.insert(1, enforced_alpha)
+        popt.insert(1, enforced_alpha)
+        perr.insert(1, np.nan)
     # Plot
     if plotq:
-       fig, ax = plot_f_vs_T(T, f, f_err, popt, p0, gamma)
+        fig, ax = plot_f_vs_T(T, f, f_err, popt, p0, gamma)
     else:
-       fig, ax = None, None
+        fig, ax = None, None
 
     if return_dataframe:
-       row = make_fit_row_f_vs_T(p0, popt, perr, gamma)
-       return row, (fig, ax)
+        row = make_fit_row_f_vs_T(p0, popt, perr, gamma)
+        return row, (fig, ax)
     return p0, popt, perr, (fig, ax)
 
 def fit_Q_vs_T(T, Q, f0_guess, gamma = 1, Tc_guess = 1.2, Q_err = None,
-               guess = None, bounds = None, return_dataframe = False,
-               plotq = False, catch_exceptions = False):
+               enforced_alpha = None, guess = None, bounds = None,
+               return_dataframe = False, plotq = False,
+               catch_exceptions = False):
     """
     Fits quality factor versus temperature data to Q_vs_T.
 
@@ -106,6 +125,8 @@ def fit_Q_vs_T(T, Q, f0_guess, gamma = 1, Tc_guess = 1.2, Q_err = None,
     Tc_guess (float): critical temperature guess in K
     Q_err (array-like or None): If not None, Q_err is the error on Q used in
         the fitting. If None, points are weighted equally
+    enforced_alpha (float or None): if not None, enforces alpha to be this
+        value. Else fits for alpha
     guess (list or None): If not None, overwrites the initial guess. Also
         overwrites f0_guess.
     bounds (list or None): custom bounds to overwrite the default option
@@ -134,17 +155,27 @@ def fit_Q_vs_T(T, Q, f0_guess, gamma = 1, Tc_guess = 1.2, Q_err = None,
     if Q_err is not None:
       Q_err = np.array(Q_err)[ix]
 
-    fit_func = lambda a, b, c, d, e, f: Q_vs_T(a, b, c, d, e, f,
-                                                  gamma = gamma)
+    if enforced_alpha is None:
+        fit_func = lambda a, b, c, d, e, f: Q_vs_T(a, b, c, d, e, f,
+                                                   gamma = gamma)
+    else:
+        fit_func = lambda a, b, d, e, f: Q_vs_T(a, b, enforced_alpha, d, e, f,
+                                                gamma = gamma)
     # Initial guess
     if guess is not None:
-        p0 = guess
-        bounds_qp, bounds_tls = get_bounds_Q_vs_T_qp(p0), get_bounds_Q_vs_T_tls(p0)
+        p0 = list(guess)
+        bounds_qp = get_bounds_Q_vs_T_qp(p0[:3] + [p0[4]])
+        bounds_tls = get_bounds_Q_vs_T_tls([p0[0], p0[3], p0[4]])
         bounds0 = get_bounds_Q_vs_T(bounds_qp, bounds_tls)
     else:
           p0, bounds0 = guess_p0_Q_vs_T(T, Q, f0_guess, Tc_guess, gamma)
     if bounds is None:
         bounds = bounds0
+    p0, bounds = p0[:], [b[:] for b in bounds]
+    if enforced_alpha is not None:
+        p0.pop(1)
+        bounds[0].pop(1)
+        bounds[1].pop(1)
     # Fit
     if Q_err is None:
         sigma = None
@@ -169,6 +200,11 @@ def fit_Q_vs_T(T, Q, f0_guess, gamma = 1, Tc_guess = 1.2, Q_err = None,
           raise e
       popt = [np.nan, np.nan, np.nan, np.nan, np.nan]
       perr = [np.nan, np.nan, np.nan, np.nan, np.nan]
+    popt, perr = list(popt), list(perr)
+    if enforced_alpha is not None and np.isfinite(popt[0]):
+        p0.insert(1, enforced_alpha)
+        popt.insert(1, enforced_alpha)
+        perr.insert(1, np.nan)
     # Plot
     if plotq:
       fig, ax = plot_Q_vs_T(T, Q, Q_err, popt, p0, gamma)
@@ -183,8 +219,9 @@ def fit_Q_vs_T(T, Q, f0_guess, gamma = 1, Tc_guess = 1.2, Q_err = None,
 ################################################################################
 ################### Resonance shift from thermal QP density ####################
 ################################################################################
-def fit_f_vs_T_qp(T, f, gamma = 1, Tc_guess = 1.2, f_err = None, guess = None,
-                  bounds = None, return_dataframe = False, plotq = False,
+def fit_f_vs_T_qp(T, f, gamma = 1, Tc_guess = 1.2, f_err = None,
+                  enforced_alpha = None, guess = None, bounds = None,
+                  return_dataframe = False, plotq = False,
                   catch_exceptions = False):
     """
     Fits resonant frequency versus temperature data to f_vs_T_qp.
@@ -196,6 +233,8 @@ def fit_f_vs_T_qp(T, f, gamma = 1, Tc_guess = 1.2, f_err = None, guess = None,
     Tc_guess (float): critical temperature guess in K
     f_err (array-like or None): If not None, f_err is the error on f used in
         the fitting. If None, points are weighted equally
+    enforced_alpha (float or None): if not None, enforces alpha to be this
+        value. Else fits for alpha
     guess (list or None): If not None, overwrites the initial guess. Also
         overwrites Tc_guess.
     bounds (list or None): custom bounds to overwrite the default option
@@ -220,15 +259,24 @@ def fit_f_vs_T_qp(T, f, gamma = 1, Tc_guess = 1.2, f_err = None, guess = None,
     if f_err is not None:
        f_err = np.array(f_err)[ix]
 
-    fit_func = lambda a, b, c, d: f_vs_T_qp(a, b, c, d, gamma = gamma)
+    if enforced_alpha is None:
+        fit_func = lambda a, b, c, d: f_vs_T_qp(a, b, c, d, gamma = gamma)
+    else:
+        fit_func = lambda a, b, d: f_vs_T_qp(a, b, enforced_alpha, d,
+                                             gamma = gamma)
     # Initial guess
     if guess is not None:
-       p0 = guess
+       p0 = list(guess)
        bounds0 = get_bounds_f_vs_T_qp(p0)
     else:
        p0, bounds0 = guess_p0_f_vs_T_qp(T, f, Tc_guess, gamma)
     if bounds is None:
        bounds = bounds0
+    p0, bounds = p0[:], [b[:] for b in bounds]
+    if enforced_alpha is not None:
+       p0.pop(1)
+       bounds[0].pop(1)
+       bounds[1].pop(1)
     # Fit
     if f_err is None:
        sigma = None
@@ -253,6 +301,11 @@ def fit_f_vs_T_qp(T, f, gamma = 1, Tc_guess = 1.2, f_err = None, guess = None,
            raise e
        popt = [np.nan, np.nan, np.nan]
        perr = [np.nan, np.nan, np.nan]
+    popt, perr = list(popt), list(perr)
+    if enforced_alpha is not None and np.isfinite(popt[0]):
+        p0.insert(1, enforced_alpha)
+        popt.insert(1, enforced_alpha)
+        perr.insert(1, np.nan)
     # Plot
     if plotq:
        fig, ax = plot_f_vs_T_qp(T, f, f_err, popt, p0, gamma)
@@ -265,8 +318,9 @@ def fit_f_vs_T_qp(T, f, gamma = 1, Tc_guess = 1.2, f_err = None, guess = None,
     return p0, popt, perr, (fig, ax)
 
 def fit_Q_vs_T_qp(T, Q, f0_guess, gamma = 1, Tc_guess = 1.2, Q_err = None,
-                  guess = None, bounds = None, return_dataframe = False,
-                  plotq = False, catch_exceptions = False):
+                  enforced_alpha = None, guess = None, bounds = None,
+                  return_dataframe = False, plotq = False,
+                  catch_exceptions = False):
     """
     Fits quality factor versus temperature data to Q_vs_T_qp.
 
@@ -278,6 +332,8 @@ def fit_Q_vs_T_qp(T, Q, f0_guess, gamma = 1, Tc_guess = 1.2, Q_err = None,
     Tc_guess (float): critical temperature guess in K
     Q_err (array-like or None): If not None, Q_err is the error on Q used in
         the fitting. If None, points are weighted equally
+    enforced_alpha (float or None): if not None, enforces alpha to be this
+        value. Else fits for alpha
     guess (list or None): If not None, overwrites the initial guess. Also
         overwrites f0_guess.
     bounds (list or None): custom bounds to overwrite the default option
@@ -304,15 +360,24 @@ def fit_Q_vs_T_qp(T, Q, f0_guess, gamma = 1, Tc_guess = 1.2, Q_err = None,
     if Q_err is not None:
         Q_err = np.array(Q_err)[ix]
 
-    fit_func = lambda a, b, c, d, e: Q_vs_T_qp(a, b, c, d, e, gamma = gamma)
+    if enforced_alpha is None:
+        fit_func = lambda a, b, c, d, e: Q_vs_T_qp(a, b, c, d, e, gamma = gamma)
+    else:
+        fit_func = lambda a, b, d, e: Q_vs_T_qp(a, b, enforced_alpha, d, e,
+                                                gamma = gamma)
     # Initial guess
     if guess is not None:
-        p0 = guess
+        p0 = list(guess)
         bounds0 = get_bounds_Q_vs_T_qp(p0)
     else:
         p0, bounds0 = guess_p0_Q_vs_T_qp(T, Q, f0_guess, Tc_guess, gamma)
     if bounds is None:
         bounds = bounds0
+    p0, bounds = p0[:], [b[:] for b in bounds]
+    if enforced_alpha is not None:
+        p0.pop(1)
+        bounds[0].pop(1)
+        bounds[1].pop(1)
     # Fit
     if Q_err is None:
         sigma = None
@@ -327,7 +392,7 @@ def fit_Q_vs_T_qp(T, Q, f0_guess, gamma = 1, Tc_guess = 1.2, Q_err = None,
         except Exception as e:
             if not catch_exceptions:
                 raise e
-         p00 = p0
+        p00 = p0
     try:
         popt, pcov = curve_fit(fit_func, T, Q, sigma = sigma,
                              p0 = p00, bounds = bounds, absolute_sigma = True)
@@ -337,6 +402,11 @@ def fit_Q_vs_T_qp(T, Q, f0_guess, gamma = 1, Tc_guess = 1.2, Q_err = None,
             raise e
         popt = [np.nan, np.nan, np.nan, np.nan]
         perr = [np.nan, np.nan, np.nan, np.nan]
+    popt, perr = list(popt), list(perr)
+    if enforced_alpha is not None and np.isfinite(popt[0]):
+        p0.insert(1, enforced_alpha)
+        popt.insert(1, enforced_alpha)
+        perr.insert(1, np.nan)
     # Plot
     if plotq:
         fig, ax = plot_Q_vs_T_qp(T, Q, Q_err, popt, p0, gamma)
@@ -389,7 +459,7 @@ def fit_f_vs_T_tls(T, f, f_err = None, guess = None, bounds = None,
     fit_func = lambda a, b, c: f_vs_T_tls(a, b, c)
     # Initial guess
     if guess is not None:
-       p0 = guess
+       p0 = list(guess)
        bounds0 = get_bounds_f_vs_T_tls(p0)
     else:
        p0, bounds0 = guess_p0_f_vs_T_tls(T, f)
@@ -419,6 +489,7 @@ def fit_f_vs_T_tls(T, f, f_err = None, guess = None, bounds = None,
             raise e
         popt = [np.nan, np.nan]
         perr = [np.nan, np.nan]
+    popt, perr = list(popt), list(perr)
     # Plot
     if plotq:
        fig, ax = plot_f_vs_T_tls(T, f, f_err, popt, p0)
@@ -471,10 +542,10 @@ def fit_Q_vs_T_tls(T, Q, f0_guess, Q_err = None,  guess = None, bounds = None,
     fit_func = lambda a, b, c, d: Q_vs_T_tls(a, b, c, d)
     # Initial guess
     if guess is not None:
-        p0 = guess
-        bounds = get_bounds_Q_vs_T_tls(p0)
+        p0 = list(guess)
+        bounds0 = get_bounds_Q_vs_T_tls(p0)
     else:
-        p0, bounds = guess_p0_Q_vs_T_tls(T, Q, f0_guess)
+        p0, bounds0 = guess_p0_Q_vs_T_tls(T, Q, f0_guess)
     if bounds is None:
         bounds = bounds0
     # Fit
@@ -501,6 +572,7 @@ def fit_Q_vs_T_tls(T, Q, f0_guess, Q_err = None,  guess = None, bounds = None,
             raise e
         popt = [np.nan, np.nan, np.nan]
         perr = [np.nan, np.nan, np.nan]
+    popt, perr = list(popt), list(perr)
     # Plot
     if plotq:
        fig, ax = plot_Q_vs_T_tls(T, Q, Q_err, popt, p0)

--- a/citkid/res_vs_temp/funcs.py
+++ b/citkid/res_vs_temp/funcs.py
@@ -13,14 +13,14 @@ N0_Nb = 6.135e48
 ################################################################################
 ############### Resonance shift from thermal QP density and TLS ################
 ################################################################################
-def f_vs_T(T, fr0, alpha, Tc, Fdelta0, gamma = 1):
+def f_vs_T(T, f0, alpha, Tc, Fdelta0, gamma = 1):
     """
     Calcuates the resonant frequency shift due to the thermal QP density and
     TLSs as a function of temperature.
 
     Parameters:
     T (float or array-like): temperature in K
-    fr0 (float): resonant frequency at T = 0 K
+    f0 (float): resonant frequency at T = 0 K
     alpha (float): kinetic inductance fraction
     Tc (float): critical temperature in K
     Fdelta0 (float): filling factor times dielectric loss at T = 0 K
@@ -30,18 +30,18 @@ def f_vs_T(T, fr0, alpha, Tc, Fdelta0, gamma = 1):
     f (float or array-like): resonant frequency(ies) at the given
         temperature(s)
     """
-    f_tls = f_vs_T_tls(T, fr0, Fdelta0)
-    f_qp = f_vs_T_qp(T, fr0, alpha, Tc, gamma = 1)
-    return f_tls + f_qp - fr0
+    f_tls = f_vs_T_tls(T, f0, Fdelta0)
+    f_qp = f_vs_T_qp(T, f0, alpha, Tc, gamma = 1)
+    return f_tls + f_qp - f0
 
-def Q_vs_T(T, fr0, alpha, Tc, Fdelta0, delta_z, gamma = 1):
+def Q_vs_T(T, f0, alpha, Tc, Fdelta0, delta_z, gamma = 1):
     """
     Calcuates the quality factor shift due to the thermal QP density and TLSs as
     a function of temperature.
 
     Parameters:
     T (float or array-like): temperature in K
-    fr0 (float): resonant frequency at T = 0 K
+    f0 (float): resonant frequency at T = 0 K
     alpha (float): kinetic inductance fraction
     Tc (float): critical temperature in K
     Fdelta0 (float): filling factor times dielectric loss at T = 0 K
@@ -51,21 +51,21 @@ def Q_vs_T(T, fr0, alpha, Tc, Fdelta0, delta_z, gamma = 1):
     Returns:
     Q (float or array-like): quality factor(s) at the given temperature(s)
     """
-    Q_tls = Q_vs_T_tls(T, fr0, Fdelta0, delta_z = 0)
-    Q_qp = Q_vs_T_qp(T, fr0, alpha, Tc, delta_z = 0, gamma = gamma)
+    Q_tls = Q_vs_T_tls(T, f0, Fdelta0, delta_z = 0)
+    Q_qp = Q_vs_T_qp(T, f0, alpha, Tc, delta_z = 0, gamma = gamma)
     return 1 / (1 / Q_tls + 1 / Q_qp + delta_z)
 
 ################################################################################
 ################### Resonance shift from thermal QP density ####################
 ################################################################################
-def f_vs_T_qp(T, fr0, alpha, Tc, gamma = 1):
+def f_vs_T_qp(T, f0, alpha, Tc, gamma = 1):
     """
     Calculates the resonant frequency shift due to the thermal QP density as a
     function of temperature.
 
     Parameters:
     T (float or array-like): temperature in K
-    fr0 (float): resonant frequency at T = 0 K
+    f0 (float): resonant frequency at T = 0 K
     alpha (float): kinetic inductance fraction
     Tc (float): critical temperature in K
     gamma (float): 1, 1/2, or 1/3 for thin-film, local, or anomalous limits
@@ -77,21 +77,21 @@ def f_vs_T_qp(T, fr0, alpha, Tc, gamma = 1):
     T = np.asarray(T)
     kT = k_B * T
     Delta0 = 1.762 * k_B * Tc
-    hf0 = h * fr0
+    hf0 = h * f0
 
     nth_N0 = nth_over_N0(kT, Delta0)
     A = - gamma * alpha / (4 * Delta0)
     x_qp = A * S2(kT, Delta0, hf0) * nth_N0
-    return fr0 * (1 + x_qp)
+    return f0 * (1 + x_qp)
 
-def Q_vs_T_qp(T, fr0, alpha, Tc, delta_z, gamma = 1):
+def Q_vs_T_qp(T, f0, alpha, Tc, delta_z, gamma = 1):
     """
     Calculates the quality factor shift due to the thermal QP density as a
     function of temperature.
 
     Parameters:
     T (float or array-like): temperature in K
-    fr0 (float): resonant frequency at T = 0 K
+    f0 (float): resonant frequency at T = 0 K
     alpha (float): kinetic inductance fraction
     Tc (float): critical temperature in K
     delta_z (float): inverse quality factor at T = 0 K
@@ -103,7 +103,7 @@ def Q_vs_T_qp(T, fr0, alpha, Tc, delta_z, gamma = 1):
     T = np.asarray(T)
     kT = k_B * T
     Delta0 = 1.762 * k_B * Tc
-    hf0 = h * fr0
+    hf0 = h * f0
 
     nth_N0 = nth_over_N0(kT, Delta0)
     A = - gamma * alpha / (2 * Delta0)
@@ -113,13 +113,13 @@ def Q_vs_T_qp(T, fr0, alpha, Tc, delta_z, gamma = 1):
 ################################################################################
 ########################### Resonance shift from TLS ###########################
 ################################################################################
-def f_vs_T_tls(T, fr0, Fdelta0):
+def f_vs_T_tls(T, f0, Fdelta0):
     """
     Calculates the resonant frequency due to TLSs as a function of temperature.
 
     Parameters:
     T (float or array-like): temperature in K
-    fr0 (float): resonant frequency at T = 0 K
+    f0 (float): resonant frequency at T = 0 K
     Fdelta0 (float): filling factor times dielectric loss at T = 0 K
 
     Returns:
@@ -128,20 +128,20 @@ def f_vs_T_tls(T, fr0, Fdelta0):
     """
     T = np.asarray(T)
     kT = k_B * T
-    xi = h * fr0 / (2 * kT)
+    xi = h * f0 / (2 * kT)
 
     G = np.real(digamma(1/2 + 1j * xi / np.pi) - np.log(xi / np.pi)) / np.pi
     x_tls = Fdelta0 * G
-    return fr0 * (1 + x_tls)
+    return f0 * (1 + x_tls)
 
-def Q_vs_T_tls(T, fr0, Fdelta0, delta_z):
+def Q_vs_T_tls(T, f0, Fdelta0, delta_z):
     """
     Calculates the quality factor shift due to TLSs as a function of
     temperature under the assumption that P_uW << P_crit(T).
 
     Parameters:
     T (float or array-like): temperature in K
-    fr0 (float): resonant frequency at T = 0 K
+    f0 (float): resonant frequency at T = 0 K
     Fdelta0 (float): filling factor times dielectric loss at T = 0 K
     delta_z (float): inverse quality factor at T = 0 K
 
@@ -150,7 +150,7 @@ def Q_vs_T_tls(T, fr0, Fdelta0, delta_z):
     """
     T = np.asarray(T)
     kT = k_B * T
-    xi = h * fr0 / (2 * kT)
+    xi = h * f0 / (2 * kT)
 
     delta = Fdelta0 * np.tanh(xi)
     return 1 / (delta + delta_z)

--- a/citkid/res_vs_temp/funcs.py
+++ b/citkid/res_vs_temp/funcs.py
@@ -5,201 +5,209 @@ from scipy.special import kv as K_n # modified bessel function of the second kin
 
 k_B = 1.380649e-23
 h = 6.62607015e-34
-hbar = h / (2*np.pi)
+hbar = h / (2 * np.pi)
+# N0 is not actually used here, but I am leaving it for reference
 N0_Al = 1.0737e47
 N0_Nb = 6.135e48
 
-def fr_vs_temp(temperature, fr0, D, alpha, Tc, gamma = 1):
+################################################################################
+############### Resonance shift from thermal QP density and TLS ################
+################################################################################
+def f_vs_T(T, fr0, alpha, Tc, Fdelta0, gamma = 1):
     """
-    Calculates the resonance frequency at the given temperature, including
-    the Mattis-Bardeen and TLS components of the temperature dependence
+    Calcuates the resonant frequency shift due to the thermal QP density and
+    TLSs as a function of temperature.
 
     Parameters:
-    temperature (float or array-like): in K
-    fr0 (float): frequency at 0 K
-    D (float): fitting parameter. See TLS write-up for details
+    T (float or array-like): temperature in K
+    fr0 (float): resonant frequency at T = 0 K
     alpha (float): kinetic inductance fraction
-    Tc (float): superconducting transition temperature in K
-    gamma (float): 1, 1/2, or 1/3 for thin-film, local, or anomalous limits.
-        This parameter should be enforced if fitting
+    Tc (float): critical temperature in K
+    Fdelta0 (float): filling factor times dielectric loss at T = 0 K
+    gamma (float): 1, 1/2, or 1/3 for thin-film, local, or anomalous limits
 
     Returns:
-    fr (float or array-like): resonance frequency(ies) at the given
+    f (float or array-like): resonant frequency(ies) at the given
         temperature(s)
     """
-    kT = k_B * temperature
-    Delta0 = 1.762 * k_B * Tc
-    zeta = Delta0 / kT
-    xi = h * fr0 / (2 * kT)
+    f_tls = f_vs_T_tls(T, fr0, Fdelta0)
+    f_qp = f_vs_T_qp(T, fr0, alpha, Tc, gamma = 1)
+    return f_tls + f_qp - fr0
 
-    g_tls = (np.real(digamma(1/2 + 1j * xi / np.pi)) - np.log(2 * xi)) / np.pi
-    # There may be a factor of 1 / 2pi in the log. Sources are inconsistent
-    g_mb = np.sqrt(2 * np.pi / zeta) + 2 * np.exp(-xi) * I_n(0, xi)
-    g_mb = - g_mb * np.exp(-zeta) / 2
-    fr = fr0 * (1 + D * g_tls + alpha * gamma * g_mb)
-    return fr
-
-def Q_vs_temp(temperature, fr0, D, alpha, Tc, A, B, m, n, delta_z,
-                 gamma = 1, N0 = N0_Al):
+def Q_vs_T(T, fr0, alpha, Tc, Fdelta0, delta_z, gamma = 1):
     """
-    Calculates the resonator quality factor at a given temperature, including
-    the Mattis-Bardeen and TLS components of the temperature dependence
+    Calcuates the quality factor shift due to the thermal QP density and TLSs as
+    a function of temperature.
 
     Parameters:
-    temperature (float or array-like): in K
-    fr0 (float): frequency at 0 K
-    D (float): fitting parameter. See TLS write-up for details
+    T (float or array-like): temperature in K
+    fr0 (float): resonant frequency at T = 0 K
     alpha (float): kinetic inductance fraction
-    Tc (float): superconducting transition temperature in K
-    A (float): model parameter. Compared to Basu Thakur 2017, A -> P / A
-    B (float): model parameter
-    m (float): model power parameter
-    n (float): model power parameter
-    delta_z (float): 1 / Qr at T = 0
-    gamma (float): 1, 1/2, or 1/3 for thin-film, local, or anomalous limits.
-        This parameter should be enforced if fitting
-    N0 (float): single-spin density of states at the Fermi Level.
-        This parameter should be enforced if fitting
+    Tc (float): critical temperature in K
+    Fdelta0 (float): filling factor times dielectric loss at T = 0 K
+    delta_z (float): inverse quality factor at T = 0 K
+    gamma (float): 1, 1/2, or 1/3 for thin-film, local, or anomalous limits
 
     Returns:
     Q (float or array-like): quality factor(s) at the given temperature(s)
     """
-    kT = k_B * temperature
-    Delta0 = 1.762 * k_B * Tc
-    zeta = Delta0 / kT
-    xi = h * fr0 / (2 * kT)
-
-    num = D * np.tanh(xi)
-    den0 = A * np.tanh(xi) ** 2 / (1 + B * np.tanh(xi) * temperature ** m)
-    den = np.sqrt(1 + den0 ** n)
-    delta_tls = num / den
-
-    omega = 2 * np.pi * fr0
-    # T << Tc approximation for the thermal quasiparticle density
-    nth = 2 * N0 * np.sqrt(2 * np.pi * kT * Delta0) * np.exp(-Delta0 / kT)
-    # T << Tc approximation of S1
-    S1 = 2 / np.pi * np.sqrt(2 * Delta0 / (np.pi * kT)) * np.sinh(xi) * K_n(0, xi)
-    delta_qp = alpha * gamma * S1 * nth / (2 * N0 * Delta0)
-
-    return 1 / (delta_tls + delta_qp + delta_z)
+    Q_tls = Q_vs_T_tls(T, fr0, Fdelta0, delta_z = 0)
+    Q_qp = Q_vs_T_qp(T, fr0, alpha, Tc, delta_z = 0, gamma = gamma)
+    return 1 / (1 / Q_tls + 1 / Q_qp + delta_z)
 
 ################################################################################
-######################### Funcs without TLS component ##########################
+################### Resonance shift from thermal QP density ####################
 ################################################################################
-def fr_vs_temp_notls(temperature, fr0, alpha, Tc, gamma = 1):
+def f_vs_T_qp(T, fr0, alpha, Tc, gamma = 1):
     """
-    Calculates the resonance frequency at the given temperature, including
-    only the Mattis-Bardeen component of the temperature dependence. This model
-    does not accurately extract the low-temperature dependence of the data if
-    TLS behavior is present.
+    Calculates the resonant frequency shift due to the thermal QP density as a
+    function of temperature.
 
     Parameters:
-    temperature (float or array-like): in K
-    fr0 (float): frequency at 0 K
+    T (float or array-like): temperature in K
+    fr0 (float): resonant frequency at T = 0 K
     alpha (float): kinetic inductance fraction
-    Tc (float): superconducting transition temperature in K
-    gamma (float): 1, 1/2, or 1/3 for thin-film, local, or anomalous limits.
-        This parameter should be enforced if fitting
+    Tc (float): critical temperature in K
+    gamma (float): 1, 1/2, or 1/3 for thin-film, local, or anomalous limits
 
     Returns:
-    fr (float or array-like): resonance frequency(ies) at the given
+    f (float or array-like): resonant frequency(ies) at the given
         temperature(s)
     """
-    kT = k_B * temperature
+    T = np.asarray(T)
+    kT = k_B * T
     Delta0 = 1.762 * k_B * Tc
-    zeta = Delta0 / kT
-    xi = h * fr0 / (2 * kT)
+    hf0 = h * fr0
 
-    g_mb = np.sqrt(2 * np.pi / zeta) + 2 * np.exp(-xi) * I_n(0, xi)
-    g_mb = - g_mb * np.exp(-zeta) / 2
-    fr = fr0 * (1 + alpha * gamma * g_mb)
-    return fr
+    nth_N0 = nth_over_N0(kT, Delta0)
+    A = - gamma * alpha / (4 * Delta0)
+    x_qp = A * S2(kT, Delta0, hf0) * nth_N0
+    return fr0 * (1 + x_qp)
 
-def Q_vs_temp_notls(temperature, fr0, alpha, Tc, delta_z,
-                 gamma = 1, N0 = N0_Al):
+def Q_vs_T_qp(T, fr0, alpha, Tc, delta_z, gamma = 1):
     """
-    Calculates the quality factor at the given temperature, including
-    only the Mattis-Bardeen component of the temperature dependence. This model
-    does not accurately extract the low-temperature dependence of the data if
-    TLS behavior is present.
+    Calculates the quality factor shift due to the thermal QP density as a
+    function of temperature.
 
     Parameters:
-    temperature (float or array-like): in K
-    fr0 (float): frequency at 0 K
+    T (float or array-like): temperature in K
+    fr0 (float): resonant frequency at T = 0 K
     alpha (float): kinetic inductance fraction
-    Tc (float): superconducting transition temperature in K
-    delta_z (float): 1 / Qr at T = 0
-    gamma (float): 1, 1/2, or 1/3 for thin-film, local, or anomalous limits.
-        This parameter should be enforced if fitting
-    N0 (float): single-spin density of states at the Fermi Level.
-        This parameter should be enforced if fitting
+    Tc (float): critical temperature in K
+    delta_z (float): inverse quality factor at T = 0 K
+    gamma (float): 1, 1/2, or 1/3 for thin-film, local, or anomalous limits
 
     Returns:
     Q (float or array-like): quality factor(s) at the given temperature(s)
     """
-    kT = k_B * temperature
+    T = np.asarray(T)
+    kT = k_B * T
     Delta0 = 1.762 * k_B * Tc
-    zeta = Delta0 / kT
-    xi = h * fr0 / (2 * kT)
+    hf0 = h * fr0
 
-    omega = 2 * np.pi * fr0
-    # T << Tc approximation for the thermal quasiparticle density
-    nth = 2 * N0 * np.sqrt(2 * np.pi * kT * Delta0) * np.exp(-Delta0 / kT)
-    # T << Tc approximation of S1
-    S1 = 2 / np.pi * np.sqrt(2 * Delta0 / (np.pi * kT)) * np.sinh(xi) * K_n(0, xi)
-    delta_qp = alpha * gamma * S1 * nth / (2 * N0 * Delta0)
+    nth_N0 = nth_over_N0(kT, Delta0)
+    A = - gamma * alpha / (2 * Delta0)
+    delta_qp = A * S1(kT, Delta0, hf0)  * nth_N0
     return 1 / (delta_qp + delta_z)
 
 ################################################################################
-######################## Funcs with only TLS component #########################
+########################### Resonance shift from TLS ###########################
 ################################################################################
-def fr_vs_temp_tls(temperature, fr0, D):
+def f_vs_T_tls(T, fr0, Fdelta0):
     """
-    Calculates the resonance frequency at the given temperature, including
-    only the TLS component of the temperature dependence. This model works at
-    low temperatures where the Mattis-Bardeen component is negligible.
+    Calculates the resonant frequency due to TLSs as a function of temperature.
 
     Parameters:
-    temperature (float or array-like): in K
-    fr0 (float): frequency at 0 K
-    D (float): fitting parameter. See TLS write-up for details
+    T (float or array-like): temperature in K
+    fr0 (float): resonant frequency at T = 0 K
+    Fdelta0 (float): filling factor times dielectric loss at T = 0 K
 
     Returns:
-    fr (float or array-like): resonance frequency(ies) at the given
+    f (float or array-like): resonant frequency(ies) at the given
         temperature(s)
     """
-    kT = k_B * temperature
+    T = np.asarray(T)
+    kT = k_B * T
     xi = h * fr0 / (2 * kT)
 
-    g_tls = (np.real(digamma(1/2 + 1j * xi / np.pi)) - np.log(2 * xi)) / np.pi
-    # There may be a factor of 1 / 2pi in the log. Sources are inconsistent
-    fr = fr0 * (1 + D * g_tls)
-    return fr
+    G = np.real(digamma(1/2 + 1j * xi / np.pi) - np.log(xi / np.pi)) / np.pi
+    x_tls = Fdelta0 * G
+    return fr0 * (1 + x_tls)
 
-def Q_vs_temp_tls(temperature, fr0, D, A, B, m, n, delta_z):
+def Q_vs_T_tls(T, fr0, Fdelta0, delta_z):
     """
-    Calculates the quality factor at the given temperature, including
-    only the TLS component of the temperature dependence. This model works at
-    low temperatures where the Mattis-Bardeen component is negligible.
+    Calculates the quality factor shift due to TLSs as a function of
+    temperature under the assumption that P_uW << P_crit(T).
 
     Parameters:
-    temperature (float or array-like): in K
-    fr0 (float): frequency at 0 K
-    D (float): fitting parameter. See TLS write-up for details
-    A (float): model parameter. Compared to Basu Thakur 2017, A -> P / A
-    B (float): model parameter
-    m (float): model power parameter
-    n (float): model power parameter
-    delta_z (float): 1 / Q at T = 0
+    T (float or array-like): temperature in K
+    fr0 (float): resonant frequency at T = 0 K
+    Fdelta0 (float): filling factor times dielectric loss at T = 0 K
+    delta_z (float): inverse quality factor at T = 0 K
 
     Returns:
     Q (float or array-like): quality factor(s) at the given temperature(s)
     """
-    kT = k_B * temperature
+    T = np.asarray(T)
+    kT = k_B * T
     xi = h * fr0 / (2 * kT)
 
-    num = D * np.tanh(xi)
-    den0 = A * np.tanh(xi) ** 2 / (1 + B * np.tanh(xi) * temperature ** m)
-    den = np.sqrt(1 + den0 ** n)
-    delta_tls = num / den
-    return 1 / (delta_tls + delta_z)
+    delta = Fdelta0 * np.tanh(xi)
+    return 1 / (delta + delta_z)
+
+################################################################################
+########################## Mattis-Bardeen Functions ############################
+################################################################################
+def S1(kT, Delta0, hf0):
+    """
+    Calculates S1(T), as defined in Foote thesis Section 2.4.
+
+    Parameters:
+    kT (float or array-like): Boltzmann constant times temperature in J
+    Delta0 (float): gap energy in J
+    hf0 (float): resonant frequency energy corresponding to f(T = 0 K) in J
+
+    Returns:
+    S1 (float): Mattis-Bardeen S1 function value
+    """
+    kT = np.asarray(kT)
+    xi = hf0 / (2 * kT)
+    A = (2 / np.pi) * np.sqrt(2 * Delta0 / (np.pi * kT))
+    S1 = A * np.sinh(xi) * K_n(0, xi)
+    return S1
+
+def S2(kT, Delta0, hf0):
+    """
+    Calculates S2(T), as defined in Foote thesis Section 2.4.
+
+    Parameters:
+    kT (float or array-like): Boltzmann constant times temperature in J
+    Delta0 (float): gap energy in J
+    hf0 (float): resonator energy corresponding to f(T = 0 K) in J
+
+    Returns:
+    S2 (float): Mattis-Bardeen S2 function value
+    """
+    kT = np.asarray(kT)
+    xi = hf0 / (2 * kT)
+    S2 = 1 + np.sqrt(2 * Delta0 / (np.pi * kT)) * np.exp(-xi) * I_n(0, xi)
+    return S2
+
+def nth_over_N0(kT, Delta0):
+    """
+    Calculates
+        nth / N0,
+    where nth is the thermal QP density and N0 is the single-spin density of
+    states at the Fermi level.
+
+    Parameters:
+    kT (float or array-like): Boltzmann constant times temperature in J
+    Delta0 (float): gap energy in J
+
+    Returns:
+    nth_N0 (float or array-like): thermal QP density divided by the single-spin
+        density of states at the Fermi level
+    """
+    kT = np.asarray(kT)
+    nth_N0 = 2 * np.sqrt(2 * np.pi * kT * Delta0) * np.exp(-Delta0 / kT)
+    return nth_N0

--- a/citkid/res_vs_temp/guess.py
+++ b/citkid/res_vs_temp/guess.py
@@ -94,7 +94,7 @@ def get_bounds_Q_vs_T(bounds_qp, bounds_tls):
     # Choose widest bounds for f0
     bounds[0][0] = min(bounds[0][0], bounds_tls[0][0])
     bounds[1][0] = max(bounds[1][0], bounds_tls[1][0])
-    # Insert Fdelt0 into index 3
+    # Insert Fdelta0 into index 3
     bounds[0].insert(3, bounds_tls[0][1])
     bounds[1].insert(3, bounds_tls[1][1])
     # Choose widest bounds for delta_z

--- a/citkid/res_vs_temp/guess.py
+++ b/citkid/res_vs_temp/guess.py
@@ -1,65 +1,22 @@
 import numpy as np
+from scipy.special import digamma
+k_B = 1.380649e-23
+h = 6.62607015e-34
+################################################################################
+############### Resonance shift from thermal QP density and TLS ################
+################################################################################
 
-def guess_p0_fr_vs_temp(temperature, fr, Tc_guess = 1.3, gamma = 1):
-    """
-    Calculates an initial guess for fr_vs_temp. Tc_guess must be provided
-
-    Parameters:
-    temperature (array-like): temperature data in K
-    fr (array-like): resonance frequency data in Hz
-    Tc_guess (float): critical temperature guess in K
-    gamma (float): 1, 1/2, or 1/3 for thin-film, local, or anomalous limits
-
-    Returns:
-    p0 (list): initial guess parameters
-        [fr0_guess, D_guess, alpha_guess, Tc_guess]
-    bounds (list): [lower_bounds, upper_bounds] for fitter corresponding to p0
-    """
-    i = np.argmax(fr)
-    ix_low = i - 2
-    if ix_low < 4:
-        ix_low = 4
-    tlow, flow = temperature[0:ix_low], fr[0:ix_low]
-    plow = np.polyfit(tlow, flow, 1)
-
-    # D guess
-    poly = [5.03204303e-11, 4.71528691e-04]
-    D_guess = np.polyval(poly, plow[0])
-    # f0 guess
-    fr0_guess = max(fr)
-    # Alpha guess
-    alpha_guess = 0.7 / gamma
-    # p0
-    p0 = [fr0_guess, D_guess, alpha_guess, Tc_guess]
-    # bounds
-    bounds = get_bounds_fr_vs_temp(p0)
-    return p0, bounds
-
-def get_bounds_fr_vs_temp(p0):
-    """
-    Gets bounds for the fitter for fr_vs_temp
-
-    Parameters:
-    p0 (list): initial guess parameters
-        [fr0_guess, D_guess, alpha_guess, Tc_guess]
-
-    Returns:
-    bounds (list): [lower_bounds, upper_bounds] for fitter corresponding to p0
-    """
-    bounds = [[p0[0] * (1 - 1e-5), p0[1] / 10, p0[2] / 3, p0[3] / 2],
-              [p0[0] * (1 + 1e-5), p0[1] * 10, p0[2] * 3, p0[3] * 2]]
-    return bounds
 
 ################################################################################
-######################### Funcs without TLS component ##########################
+################### Resonance shift from thermal QP density ####################
 ################################################################################
-def guess_p0_fr_vs_temp_notls(temperature, fr, Tc_guess = 1.3, gamma = 1):
+def guess_p0_f_vs_T_qp(T, fr, Tc_guess = 1.2, gamma = 1):
     """
-    Calculates an initial guess for fr_vs_temp_notls. Tc_guess must be provided
+    Calculates an initial guess for f_vs_T_qp. Tc_guess must be provided.
 
     Parameters:
-    temperature (array-like): temperature data in K
-    fr (array-like): resonance frequency data in Hz
+    T (array-like): temperature data in K
+    fr (array-like): resonant frequency data in Hz
     Tc_guess (float): critical temperature guess in K
     gamma (float): 1, 1/2, or 1/3 for thin-film, local, or anomalous limits
 
@@ -72,15 +29,14 @@ def guess_p0_fr_vs_temp_notls(temperature, fr, Tc_guess = 1.3, gamma = 1):
     fr0_guess = max(fr)
     # Alpha guess
     alpha_guess = 0.7 / gamma
-    # p0
+    # p0, bounds
     p0 = [fr0_guess, alpha_guess, Tc_guess]
-    # bounds
-    bounds = get_bounds_fr_vs_temp_notls(p0)
+    bounds = get_bounds_f_vs_T_qp(p0)
     return p0, bounds
 
-def get_bounds_fr_vs_temp_notls(p0):
+def get_bounds_f_vs_T_qp(p0):
     """
-    Gets bounds for the fitter for fr_vs_temp_notls
+    Gets bounds for the fitter for f_vs_T_qp
 
     Parameters:
     p0 (list): initial guess parameters
@@ -89,25 +45,21 @@ def get_bounds_fr_vs_temp_notls(p0):
     Returns:
     bounds (list): [lower_bounds, upper_bounds] for fitter corresponding to p0
     """
-    bounds = [[p0[0] * (1 - 1e-5), p0[1] / 3, p0[2] / 2],
-              [p0[0] * (1 + 1e-5), p0[1] * 3, p0[2] * 2]]
+    bounds = [[p0[0] * (1 - 1e-5), p0[1] / 3,         p0[2] / 2],
+              [p0[0] * (1 + 1e-5), max(p0[1] * 3, 1), p0[2] * 2]]
     return bounds
 
-def guess_p0_Q_vs_temp_notls(temperature, Q, fr0_guess, gamma, N0,
-                             alpha_guess = 0.7, Tc_guess = None):
+def guess_p0_Q_vs_T_qp(T, Q, fr0_guess, Tc_guess = 1.2, gamma = 1):
     """
-    Calculates an initial guess for Q_vs_temp_notls
-    I haven't tested this for N0 different from N0_Al
+    Calculates an initial guess for Q_vs_T_qp. Tc_guess and fr0_guess must be
+    provided.
 
     Parameters:
-    temperature (array-like): temperature data in K
+    T (array-like): temperature data in K
     Q (array-like): quality factor data
     fr0_guess (float): guess for fr0 in Hz
+    Tc_guess (float or None): critical temperature guess in K
     gamma (float): 1, 1/2, or 1/3 for thin-film, local, or anomalous limits
-    N0 (float): single-spin density of states at the Fermi Level
-    alpha_guess (float): kinetic inductance fraction guess
-    Tc_guess (float or None): critical temperature guess in K, or None to guess
-        using the data
 
     Returns:
     p0 (list): initial guess parameters
@@ -115,28 +67,17 @@ def guess_p0_Q_vs_temp_notls(temperature, Q, fr0_guess, gamma, N0,
     bounds (list): [lower_bounds, upper_bounds] for fitter corresponding to p0
     """
     # delta_z guess
-    delta_z_guess = 1 / max(Q)
+    delta_z_guess = 1 / min(Q)
     # alpha guess
     alpha_guess = 0.7 / gamma
-    # Tc guess
-    if Tc_guess is None:
-        ix = np.argmax(Q)
-        Q1 = Q[ix:]
-        Tc0 = np.where(Q1 < Q[ix] / 2)[0]
-        if len(Tc0):
-            Tc0 = temperature[Tc0[0]]
-        else:
-            Tc0 = temperature[-1]
-        poly = [ 0.03088547, -2.58625446,  9.9405062 , -0.46576281]
-        Tc_guess = np.polyval(poly, Tc0)
-    # Create p0
+    # p0, bounds
     p0 = [fr0_guess, alpha_guess, Tc_guess, delta_z_guess]
-    bounds = get_bounds_Q_vs_temp_notls(p0)
+    bounds = get_bounds_Q_vs_T_qp(p0)
     return p0, bounds
 
-def get_bounds_Q_vs_temp_notls(p0):
+def get_bounds_Q_vs_T_qp(p0):
     """
-    Gets bounds for the fitter for Q_vs_temp_notls
+    Gets bounds for the fitter for Q_vs_T_qp.
 
     Parameters:
     p0 (list): initial guess parameters
@@ -145,56 +86,91 @@ def get_bounds_Q_vs_temp_notls(p0):
     Returns:
     bounds (list): [lower_bounds, upper_bounds] for fitter corresponding to p0
     """
-    bounds = [[p0[0] * (1 - 1e-5), p0[1] / 3, p0[2] / 2, p0[3] / 10],
-              [p0[0] * (1 + 1e-5), p0[1] * 3, p0[2] * 2, p0[3] * 10]]
+    bounds = [[p0[0] * (1 - 1e-5), p0[1] / 3,         p0[2] / 2, p0[3] / 10],
+              [p0[0] * (1 + 1e-5), max(p0[1] * 3, 1), p0[2] * 2, p0[3] * 10]]
     return bounds
 
-
 ################################################################################
-######################## Funcs with only TLS component #########################
+########################### Resonance shift from TLS ###########################
 ################################################################################
-def guess_p0_fr_vs_temp_tls(temperature, fr):
+def guess_p0_f_vs_T_tls(T, f):
     """
-    Calculates an initial guess for fr_vs_temp_tls
+    Calculates an initial guess for f_vs_T
 
     Parameters:
-    temperature (array-like): temperature data in K
-    fr (array-like): resonance frequency data in Hz
+    T (array-like): temperature data in K
+    f (array-like): resonant frequency data in Hz
 
     Returns:
     p0 (list): initial guess parameters
         [fr0_guess, D_guess]
     bounds (list): [lower_bounds, upper_bounds] for fitter corresponding to p0
     """
-    i = np.argmax(fr)
-    ix_low = i - 2
-    if ix_low < 4:
-        ix_low = 4
-    tlow, flow = temperature[0:ix_low], fr[0:ix_low]
-    plow = np.polyfit(tlow, flow, 1)
-
-    # D guess
-    poly = [5.03204303e-11, 4.71528691e-04]
-    D_guess = np.polyval(poly, plow[0])
-    # f0 guess
-    fr0_guess = max(fr)
-
-    p0 = [fr0_guess, D_guess]
-    # bounds
-    bounds = get_bounds_fr_vs_temp_tls(p0)
+    fr0_guess = np.median(f)
+    xi = h * fr0_guess / (2 * k_B * T)
+    G = np.real(digamma(1/2 + 1j * xi / np.pi) - np.log(xi / np.pi)) / np.pi
+    fr0_guess = np.polyfit(G, f, 1)[1]
+    # fr0_guess = max(f)
+    # Fdelta0 guess
+    xi = h * fr0_guess / (2 * k_B * T)
+    G = np.real(digamma(1/2 + 1j * xi / np.pi) - np.log(xi / np.pi)) / np.pi
+    Fdelta0_guess = np.polyfit(G, (f - fr0_guess) / fr0_guess, 1)[0]
+    Fdelta0_guess = max(Fdelta0_guess, 1e-6)
+    # p0, bounds
+    p0 = [fr0_guess, Fdelta0_guess]
+    bounds = get_bounds_f_vs_T_tls(p0)
     return p0, bounds
 
-def get_bounds_fr_vs_temp_tls(p0):
+def get_bounds_f_vs_T_tls(p0):
     """
-    Gets bounds for the fitter for fr_vs_temp_tls
+    Gets bounds for the fitter for f_vs_T_tls.
 
     Parameters:
     p0 (list): initial guess parameters
-        [fr0_guess, D_guess]
+        [fr0_guess, Fdelta0_guess]
 
     Returns:
     bounds (list): [lower_bounds, upper_bounds] for fitter corresponding to p0
     """
-    bounds = [[p0[0] * (1 - 1e-5), p0[1] / 10],
-              [p0[0] * (1 + 1e-5), p0[1] * 10]]
+    bounds = [[p0[0] * (1 - 1e-5), p0[1] / 3],
+              [p0[0] * (1 + 1e-5), p0[1] * 3]]
+    return bounds
+
+def guess_p0_Q_vs_T_tls(T, Q, fr0_guess):
+    """
+    Calculates an initial guess for Q_vs_T. fr0_guess must be provided.
+
+    Parameters:
+    T (array-like): temperature data in K
+    Q (array-like): quality factor data in Hz
+
+    Returns:
+    p0 (list): initial guess parameters
+        [fr0_guess, Fdelta0_guess, delta_z_guess]
+    bounds (list): [lower_bounds, upper_bounds] for fitter corresponding to p0
+    """
+    xi = h * fr0_guess / (2 * k_B * T)
+    x = np.tanh(xi)
+    Qinv = 1 / Q
+    m, b = np.polyfit(x, Qinv, 1)
+    delta_z_guess = b
+    Fdelta0_guess = m
+    # p0, bounds
+    p0 = [fr0_guess, Fdelta0_guess, delta_z_guess]
+    bounds = get_bounds_Q_vs_T_tls(p0)
+    return p0, bounds
+
+def get_bounds_Q_vs_T_tls(p0):
+    """
+    Gets bounds for the fitter for Q_vs_T_tls.
+
+    Parameters:
+    p0 (list): initial guess parameters
+        [fr0_guess, Fdelta0_guess, delta_z_guess]
+
+    Returns:
+    bounds (list): [lower_bounds, upper_bounds] for fitter corresponding to p0
+    """
+    bounds = [[p0[0] * (1 - 1e-5), p0[1] / 10, p0[2] / 10],
+              [p0[0] * (1 + 1e-5), p0[1] * 10, p0[2] * 10]]
     return bounds

--- a/citkid/res_vs_temp/guess.py
+++ b/citkid/res_vs_temp/guess.py
@@ -5,42 +5,137 @@ h = 6.62607015e-34
 ################################################################################
 ############### Resonance shift from thermal QP density and TLS ################
 ################################################################################
-
-
-################################################################################
-################### Resonance shift from thermal QP density ####################
-################################################################################
-def guess_p0_f_vs_T_qp(T, fr, Tc_guess = 1.2, gamma = 1):
+def guess_p0_f_vs_T(T, f, Tc_guess = 1.2, gamma = 1):
     """
-    Calculates an initial guess for f_vs_T_qp. Tc_guess must be provided.
+    Calculates an initial guess for f_vs_T. Tc_guess must be provided.
 
     Parameters:
     T (array-like): temperature data in K
-    fr (array-like): resonant frequency data in Hz
+    f (array-like): resonant frequency data in Hz
     Tc_guess (float): critical temperature guess in K
     gamma (float): 1, 1/2, or 1/3 for thin-film, local, or anomalous limits
 
     Returns:
     p0 (list): initial guess parameters
-        [fr0_guess, alpha_guess, Tc_guess]
+        [f0_guess, alpha_guess, Tc_guess, Fdelta0_guess]
+    bounds (list): [lower_bounds, upper_bounds] for fitter corresponding to p0
+    """
+    ix = min(len(T) // 2, (len(T) - 4))
+    p0_qp, bounds_qp = guess_p0_f_vs_T_qp(T[ix:], f[ix:], Tc_guess = Tc_guess,
+                                    gamma = gamma)
+    ix = max(len(T) // 2, 4)
+    p0_tls, bounds_tls = guess_p0_f_vs_T_tls(T[:ix], f[:ix])
+    p0 = [np.min([p0_qp[0], p0_tls[0]]), p0_qp[1], p0_qp[2], p0_tls[1]]
+          # ^ both tend to overestimate f0
+    bounds = get_bounds_f_vs_T(bounds_qp, bounds_tls)
+    return p0, bounds
+
+def get_bounds_f_vs_T(bounds_qp, bounds_tls):
+    """
+    Gets bounds for the fitter for f_vs_T.
+
+    Parameters:
+    bounds_qp (list): bounds from the QP guessing function
+    bounds_tls (list): bounds from the TLS guessing function
+
+    Returns:
+    bounds (list): [lower_bounds, upper_bounds] for fitter
+    """
+    bounds = [b[:] for b in bounds_qp]
+    # choose widest bounds for f0
+    bounds[0][0] = min(bounds[0][0], bounds_tls[0][0])
+    bounds[1][0] = max(bounds[1][0], bounds_tls[1][0])
+    # append Fdelta0 to the end of bounds_qp
+    bounds[0].append(bounds_tls[0][1])
+    bounds[1].append(bounds_tls[1][1])
+    return bounds
+
+def guess_p0_Q_vs_T(T, Q, f0_guess, Tc_guess = 1.2, gamma = 1):
+    """
+    Calculates an initial guess for Q_vs_T. Tc_guess and f0_guess must be
+    provided.
+
+    Parameters:
+    T (array-like): temperature data in K
+    Q (array-like): quality factor data
+    f0_guess (float): guess for f0 in Hz
+    Tc_guess (float or None): critical temperature guess in K
+    gamma (float): 1, 1/2, or 1/3 for thin-film, local, or anomalous limits
+
+    Returns:
+    p0 (list): initial guess parameters
+        [f0_guess, alpha_guess, Tc_guess, Fdelta0_guess, delta_z_guess]
+    bounds (list): [lower_bounds, upper_bounds] for fitter corresponding to p0
+    """
+    ix = min(len(T) // 2, (len(T) - 4))
+    p0_qp, bounds_qp = guess_p0_Q_vs_T_qp(T[ix:], Q[ix:], f0_guess = f0_guess,
+                                          Tc_guess = Tc_guess, gamma = gamma)
+    ix = max(len(T) // 2, 4)
+    p0_tls, bounds_tls = guess_p0_Q_vs_T_tls(T[:ix], Q[:ix],
+                                             f0_guess = f0_guess)
+    p0 = [p0_qp[0], p0_qp[1], p0_qp[2], p0_tls[1], p0_qp[3]]
+    #     ^ f0 is the same for both               ^ QP does a better job at
+    #                                                extracting delta_z
+    bounds = get_bounds_Q_vs_T(bounds_qp, bounds_tls)
+    return p0, bounds
+
+def get_bounds_Q_vs_T(bounds_qp, bounds_tls):
+    """
+    Gets bounds for the fitter for Q_vs_T.
+
+    Parameters:
+    bounds_qp (list): bounds from the QP guessing function
+    bounds_tls (list): bounds from the TLS guessing function
+
+    Returns:
+    bounds (list): [lower_bounds, upper_bounds] for fitter
+    """
+    bounds = [b[:] for b in bounds_qp]
+    # Choose widest bounds for f0
+    bounds[0][0] = min(bounds[0][0], bounds_tls[0][0])
+    bounds[1][0] = max(bounds[1][0], bounds_tls[1][0])
+    # Insert Fdelt0 into index 3
+    bounds[0].insert(3, bounds_tls[0][1])
+    bounds[1].insert(3, bounds_tls[1][1])
+    # Choose widest bounds for delta_z
+    bounds[0][4] = min(bounds[0][4], bounds_tls[0][2])
+    bounds[1][4] = max(bounds[1][4], bounds_tls[1][2])
+    return bounds
+
+################################################################################
+################### Resonance shift from thermal QP density ####################
+################################################################################
+def guess_p0_f_vs_T_qp(T, f, Tc_guess = 1.2, gamma = 1):
+    """
+    Calculates an initial guess for f_vs_T_qp. Tc_guess must be provided.
+
+    Parameters:
+    T (array-like): temperature data in K
+    f (array-like): resonant frequency data
+    Tc_guess (float): critical temperature guess in K
+    gamma (float): 1, 1/2, or 1/3 for thin-film, local, or anomalous limits
+
+    Returns:
+    p0 (list): initial guess parameters
+        [f0_guess, alpha_guess, Tc_guess]
     bounds (list): [lower_bounds, upper_bounds] for fitter corresponding to p0
     """
     # f0 guess
-    fr0_guess = max(fr)
+    f0_guess = max(f)
     # Alpha guess
     alpha_guess = 0.7 / gamma
     # p0, bounds
-    p0 = [fr0_guess, alpha_guess, Tc_guess]
+    p0 = [f0_guess, alpha_guess, Tc_guess]
     bounds = get_bounds_f_vs_T_qp(p0)
     return p0, bounds
 
 def get_bounds_f_vs_T_qp(p0):
     """
-    Gets bounds for the fitter for f_vs_T_qp
+    Gets bounds for the fitter for f_vs_T_qp.
 
     Parameters:
     p0 (list): initial guess parameters
-        [fr0_guess, alpha_guess, Tc_guess]
+        [f0_guess, alpha_guess, Tc_guess]
 
     Returns:
     bounds (list): [lower_bounds, upper_bounds] for fitter corresponding to p0
@@ -49,21 +144,21 @@ def get_bounds_f_vs_T_qp(p0):
               [p0[0] * (1 + 1e-5), max(p0[1] * 3, 1), p0[2] * 2]]
     return bounds
 
-def guess_p0_Q_vs_T_qp(T, Q, fr0_guess, Tc_guess = 1.2, gamma = 1):
+def guess_p0_Q_vs_T_qp(T, Q, f0_guess, Tc_guess = 1.2, gamma = 1):
     """
-    Calculates an initial guess for Q_vs_T_qp. Tc_guess and fr0_guess must be
+    Calculates an initial guess for Q_vs_T_qp. Tc_guess and f0_guess must be
     provided.
 
     Parameters:
     T (array-like): temperature data in K
     Q (array-like): quality factor data
-    fr0_guess (float): guess for fr0 in Hz
+    f0_guess (float): guess for f0 in Hz
     Tc_guess (float or None): critical temperature guess in K
     gamma (float): 1, 1/2, or 1/3 for thin-film, local, or anomalous limits
 
     Returns:
     p0 (list): initial guess parameters
-        [fr0_guess, alpha_guess, Tc_guess, delta_z_guess]
+        [f0_guess, alpha_guess, Tc_guess, delta_z_guess]
     bounds (list): [lower_bounds, upper_bounds] for fitter corresponding to p0
     """
     # delta_z guess
@@ -71,7 +166,7 @@ def guess_p0_Q_vs_T_qp(T, Q, fr0_guess, Tc_guess = 1.2, gamma = 1):
     # alpha guess
     alpha_guess = 0.7 / gamma
     # p0, bounds
-    p0 = [fr0_guess, alpha_guess, Tc_guess, delta_z_guess]
+    p0 = [f0_guess, alpha_guess, Tc_guess, delta_z_guess]
     bounds = get_bounds_Q_vs_T_qp(p0)
     return p0, bounds
 
@@ -81,7 +176,7 @@ def get_bounds_Q_vs_T_qp(p0):
 
     Parameters:
     p0 (list): initial guess parameters
-        [fr0_guess, alpha_guess, Tc_guess, delta_z_guess]
+        [f0_guess, alpha_guess, Tc_guess, delta_z_guess]
 
     Returns:
     bounds (list): [lower_bounds, upper_bounds] for fitter corresponding to p0
@@ -95,7 +190,7 @@ def get_bounds_Q_vs_T_qp(p0):
 ################################################################################
 def guess_p0_f_vs_T_tls(T, f):
     """
-    Calculates an initial guess for f_vs_T
+    Calculates an initial guess for f_vs_T_tls.
 
     Parameters:
     T (array-like): temperature data in K
@@ -103,21 +198,21 @@ def guess_p0_f_vs_T_tls(T, f):
 
     Returns:
     p0 (list): initial guess parameters
-        [fr0_guess, D_guess]
+        [f0_guess, Fdelta0_guess]
     bounds (list): [lower_bounds, upper_bounds] for fitter corresponding to p0
     """
-    fr0_guess = np.median(f)
-    xi = h * fr0_guess / (2 * k_B * T)
+    f0_guess = np.median(f)
+    xi = h * f0_guess / (2 * k_B * T)
     G = np.real(digamma(1/2 + 1j * xi / np.pi) - np.log(xi / np.pi)) / np.pi
-    fr0_guess = np.polyfit(G, f, 1)[1]
-    # fr0_guess = max(f)
+    f0_guess = np.polyfit(G, f, 1)[1]
+    # f0_guess = max(f)
     # Fdelta0 guess
-    xi = h * fr0_guess / (2 * k_B * T)
+    xi = h * f0_guess / (2 * k_B * T)
     G = np.real(digamma(1/2 + 1j * xi / np.pi) - np.log(xi / np.pi)) / np.pi
-    Fdelta0_guess = np.polyfit(G, (f - fr0_guess) / fr0_guess, 1)[0]
+    Fdelta0_guess = np.polyfit(G, (f - f0_guess) / f0_guess, 1)[0]
     Fdelta0_guess = max(Fdelta0_guess, 1e-6)
     # p0, bounds
-    p0 = [fr0_guess, Fdelta0_guess]
+    p0 = [f0_guess, Fdelta0_guess]
     bounds = get_bounds_f_vs_T_tls(p0)
     return p0, bounds
 
@@ -127,7 +222,7 @@ def get_bounds_f_vs_T_tls(p0):
 
     Parameters:
     p0 (list): initial guess parameters
-        [fr0_guess, Fdelta0_guess]
+        [f0_guess, Fdelta0_guess]
 
     Returns:
     bounds (list): [lower_bounds, upper_bounds] for fitter corresponding to p0
@@ -136,27 +231,28 @@ def get_bounds_f_vs_T_tls(p0):
               [p0[0] * (1 + 1e-5), p0[1] * 3]]
     return bounds
 
-def guess_p0_Q_vs_T_tls(T, Q, fr0_guess):
+def guess_p0_Q_vs_T_tls(T, Q, f0_guess):
     """
-    Calculates an initial guess for Q_vs_T. fr0_guess must be provided.
+    Calculates an initial guess for Q_vs_T_tls. f0_guess must be provided.
 
     Parameters:
     T (array-like): temperature data in K
-    Q (array-like): quality factor data in Hz
+    Q (array-like): quality factor data
+    f0_guess (float): guess for f0 in Hz
 
     Returns:
     p0 (list): initial guess parameters
-        [fr0_guess, Fdelta0_guess, delta_z_guess]
+        [f0_guess, Fdelta0_guess, delta_z_guess]
     bounds (list): [lower_bounds, upper_bounds] for fitter corresponding to p0
     """
-    xi = h * fr0_guess / (2 * k_B * T)
+    xi = h * f0_guess / (2 * k_B * T)
     x = np.tanh(xi)
     Qinv = 1 / Q
     m, b = np.polyfit(x, Qinv, 1)
     delta_z_guess = b
     Fdelta0_guess = m
     # p0, bounds
-    p0 = [fr0_guess, Fdelta0_guess, delta_z_guess]
+    p0 = [f0_guess, Fdelta0_guess, delta_z_guess]
     bounds = get_bounds_Q_vs_T_tls(p0)
     return p0, bounds
 
@@ -166,7 +262,7 @@ def get_bounds_Q_vs_T_tls(p0):
 
     Parameters:
     p0 (list): initial guess parameters
-        [fr0_guess, Fdelta0_guess, delta_z_guess]
+        [f0_guess, Fdelta0_guess, delta_z_guess]
 
     Returns:
     bounds (list): [lower_bounds, upper_bounds] for fitter corresponding to p0

--- a/citkid/res_vs_temp/plot.py
+++ b/citkid/res_vs_temp/plot.py
@@ -1,15 +1,19 @@
 import matplotlib.pyplot as plt
 import numpy as np
 from .funcs import *
+from matplotlib.ticker import ScalarFormatter
 
-def plot_fr_vs_temp(temperature, fr, fr_err, popt, p0, gamma):
+################################################################################
+############### Resonance shift from thermal QP density and TLS ################
+################################################################################
+def plot_f_vs_T(T, f, f_err, popt, p0, gamma):
     """
-    Plots the fit and initial guess to fr_vs_temp
+    Plots the fit and initial guess to f_vs_T.
 
     Parameters:
-    temperature (array-like): temperature data in K
-    fr (array-like): resonance frequency data in Hz
-    fr_err (None or array-like): error bars for the plot, or None to plot
+    T (array-like): temperature data in K
+    f (array-like): resonant frequency data in Hz
+    f_err (None or array-like): error bars for the plot, or None to plot
         without error bars
     popt (list): fit parameters
     p0 (list): initial guess parameters
@@ -18,116 +22,155 @@ def plot_fr_vs_temp(temperature, fr, fr_err, popt, p0, gamma):
     Returns:
     fig, ax: pyplot figure and axis, or (None, None) if not plotq
     """
-    fig, ax = plt.subplots(figsize = [3, 2.8], dpi = 200, layout = 'tight')
-    ax.set_ylabel(r'$f_r$ (MHz)')
-    ax.set_xlabel(r'Temperature (K)')
-    ax.set_xscale('log')
-    if fr_err is None:
-        ax.plot(temperature, fr * 1e-6, marker = '.', color = plt.cm.viridis(0),
+    f0 = popt[0]
+    fig, ax = setup_f_vs_T(f0)
+    ax.set_title('f vs T, thermal QP + TLS shift')
+
+    if f_err is None:
+        ax.plot(T * 1e3, (f - f0) * 1e-3, marker = '.', color = plt.cm.viridis(0),
                 linestyle = '', label = 'Data')
     else:
-        ax.errorbar(temperature, fr * 1e-6, yerr = fr_err * 1e-6, marker = '.',
+        ax.errorbar(T * 1e3, (f - f0) * 1e-3, yerr = f_err * 1e-3, marker = '.',
                     color = plt.cm.viridis(0), linestyle = '', label = 'Data')
+        ax.set_xlim(min(T) * 0.96e3, max(T) * 1.04e3)
 
-    xsamp = np.geomspace(min(temperature), max(temperature), 200)
-    ysamp = fr_vs_temp(xsamp, *popt, gamma = gamma)
-    ax.plot(xsamp, ysamp * 1e-6, '--r', label = 'Fit')
+    xsamp = np.geomspace(min(T), max(T), 200)
+    ysamp = f_vs_T(xsamp, *popt, gamma = gamma)
+    ax.plot(xsamp * 1e3, (ysamp - f0) * 1e-3, '--r', label = 'Fit')
     ylim = ax.get_ylim()
-    ysamp = fr_vs_temp(xsamp, *p0, gamma = gamma)
-    ax.plot(xsamp, ysamp * 1e-6, ':k', label = 'Guess')
+    ysamp = f_vs_T(xsamp, *p0, gamma = gamma)
+    ax.plot(xsamp * 1e3, (ysamp - f0) * 1e-3, ':k', label = 'Guess')
     ax.set_ylim(ylim)
-    ax.legend()
+    ax.legend(framealpha = 1)
     return fig, ax
 
-################################################################################
-######################### Funcs without TLS component ##########################
-################################################################################
-def plot_fr_vs_temp_notls(temperature, fr, fr_err, popt, p0, gamma):
+def plot_Q_vs_T(T, Q, Q_err, popt, p0, gamma):
     """
-    Plots the fit and initial guess to fr_vs_temp_notls
+    Plots the fit and initial guess to Q_vs_T.
 
     Parameters:
-    temperature (array-like): temperature data in K
-    fr (array-like): resonance frequency data in Hz
-    fr_err (None or array-like): error bars for the plot, or None to plot
-        without error bars
-    popt (list): fit parameters
-    p0 (list): initial guess parameters
-    gamma (float): 1, 1/2, or 1/3 for thin-film, local, or anomalous limits
-
-    Returns:
-    fig, ax: pyplot figure and axis, or (None, None) if not plotq
-    """
-    fig, ax = plt.subplots(figsize = [3, 2.8], dpi = 200, layout = 'tight')
-    ax.set_ylabel(r'$f_r$ (MHz)')
-    ax.set_xlabel(r'Temperature (K)')
-    ax.set_xscale('log')
-    if fr_err is None:
-        ax.plot(temperature, fr * 1e-6, marker = '.', color = plt.cm.viridis(0),
-                linestyle = '', label = 'Data')
-    else:
-        ax.errorbar(temperature, fr * 1e-6, yerr = fr_err * 1e-6, marker = '.',
-                    color = plt.cm.viridis(0), linestyle = '', label = 'Data')
-
-    xsamp = np.geomspace(min(temperature), max(temperature), 200)
-    ysamp = fr_vs_temp_notls(xsamp, *popt, gamma = gamma)
-    ax.plot(xsamp, ysamp * 1e-6, '--r', label = 'Fit')
-    ylim = ax.get_ylim()
-    ysamp = fr_vs_temp_notls(xsamp, *p0, gamma = gamma)
-    ax.plot(xsamp, ysamp * 1e-6, ':k', label = 'Guess')
-    ax.set_ylim(ylim)
-    ax.legend()
-    return fig, ax
-
-def plot_Q_vs_temp_notls(temperature, Q, Q_err, popt, p0, gamma, N0):
-    """
-    Plots the fit and initial guess to Q_vs_temp_notls
-
-    Parameters:
-    temperature (array-like): temperature data in K
+    T (array-like): temperature data in K
     Q (array-like): quality factor data
     Q_err (None or array-like): error bars for the plot, or None to plot
         without error bars
     popt (list): fit parameters
     p0 (list): initial guess parameters
     gamma (float): 1, 1/2, or 1/3 for thin-film, local, or anomalous limits
-    N0 (float): single-spin density of states at the Fermi Level
 
     Returns:
     fig, ax: pyplot figure and axis, or (None, None) if not plotq
     """
-    fig, ax = plt.subplots(figsize = [3, 2.8], dpi = 200, layout = 'tight')
-    ax.set_ylabel(r'$Q$ (kHz / GHz)')
-    ax.set_xlabel(r'Temperature (K)')
-    ax.set_xscale('log')
+    f0 = popt[0]
+    fig, ax = setup_Q_vs_T()
+    ax.set_title('Q vs T, thermal QP + TLS shift')
+
     if Q_err is None:
-        ax.plot(temperature, Q * 1e-6, marker = '.', color = plt.cm.viridis(0),
+        ax.plot(T * 1e3, Q * 1e-3, marker = '.', color = plt.cm.viridis(0),
                 linestyle = '', label = 'Data')
     else:
-        ax.errorbar(temperature, Q * 1e-6, yerr = Q_err * 1e-6, marker = '.',
+        ax.errorbar(T * 1e3, Q * 1e-3, yerr = Q_err * 1e-3, marker = '.',
                     color = plt.cm.viridis(0), linestyle = '', label = 'Data')
+        ax.set_xlim(min(T) * 0.96e3, max(T) * 1.04e3)
 
-    xsamp = np.geomspace(min(temperature), max(temperature), 200)
-    ysamp = Q_vs_temp_notls(xsamp, *popt, gamma = gamma, N0 = N0)
-    ax.plot(xsamp, ysamp * 1e-6, '--r', label = 'Fit')
+    xsamp = np.geomspace(min(T), max(T), 200)
+    ysamp = Q_vs_T(xsamp, *popt, gamma = gamma)
+    ax.plot(xsamp * 1e3, ysamp * 1e-3, '--r', label = 'Fit')
     ylim = ax.get_ylim()
-    ysamp = Q_vs_temp_notls(xsamp, *p0, gamma = gamma, N0 = N0)
-    ax.plot(xsamp, ysamp * 1e-6, ':k', label = 'Guess')
+    ysamp = Q_vs_T(xsamp, *p0, gamma = gamma)
+    ax.plot(xsamp * 1e3, ysamp * 1e-3, ':k', label = 'Guess')
     ax.set_ylim(ylim)
-    ax.legend()
+    ax.legend(framealpha = 1)
     return fig, ax
 
 ################################################################################
-######################## Funcs with only TLS component #########################
+################### Resonance shift from thermal QP density ####################
 ################################################################################
-def plot_fr_vs_temp_tls(temperature, fr, fr_err, popt, p0):
+def plot_f_vs_T_qp(T, f, f_err, popt, p0, gamma):
     """
-    Plots the fit and initial guess to fr_vs_temp_tls
+    Plots the fit and initial guess to f_vs_T_qp.
 
     Parameters:
-    temperature (array-like): temperature data in K
-    fr (array-like): resonance frequency data in Hz
-    fr_err (None or array-like): error bars for the plot, or None to plot
+    T (array-like): temperature data in K
+    f (array-like): resonant frequency data in Hz
+    f_err (None or array-like): error bars for the plot, or None to plot
+        without error bars
+    popt (list): fit parameters
+    p0 (list): initial guess parameters
+    gamma (float): 1, 1/2, or 1/3 for thin-film, local, or anomalous limits
+
+    Returns:
+    fig, ax: pyplot figure and axis, or (None, None) if not plotq
+    """
+    f0 = popt[0]
+    fig, ax = setup_f_vs_T(f0)
+    ax.set_title('f vs T, thermal QP shift')
+
+    if f_err is None:
+        ax.plot(T * 1e3, (f - f0) * 1e-3, marker = '.', color = plt.cm.viridis(0),
+                linestyle = '', label = 'Data')
+    else:
+        ax.errorbar(T * 1e3, (f - f0) * 1e-3, yerr = f_err * 1e-3, marker = '.',
+                    color = plt.cm.viridis(0), linestyle = '', label = 'Data')
+        ax.set_xlim(min(T) * 0.96e3, max(T) * 1.04e3)
+
+    xsamp = np.geomspace(min(T), max(T), 200)
+    ysamp = f_vs_T_qp(xsamp, *popt, gamma = gamma)
+    ax.plot(xsamp * 1e3, (ysamp - f0) * 1e-3, '--r', label = 'Fit')
+    ylim = ax.get_ylim()
+    ysamp = f_vs_T_qp(xsamp, *p0, gamma = gamma)
+    ax.plot(xsamp * 1e3, (ysamp - f0) * 1e-3, ':k', label = 'Guess')
+    ax.set_ylim(ylim)
+    ax.legend(framealpha = 1)
+    return fig, ax
+
+def plot_Q_vs_T_qp(T, Q, Q_err, popt, p0, gamma):
+    """
+    Plots the fit and initial guess to Q_vs_T_qp.
+
+    Parameters:
+    T (array-like): temperature data in K
+    Q (array-like): quality factor data
+    Q_err (None or array-like): error bars for the plot, or None to plot
+        without error bars
+    popt (list): fit parameters
+    p0 (list): initial guess parameters
+    gamma (float): 1, 1/2, or 1/3 for thin-film, local, or anomalous limits
+
+    Returns:
+    fig, ax: pyplot figure and axis, or (None, None) if not plotq
+    """
+    fig, ax = setup_Q_vs_T()
+    ax.set_title('Q vs T, thermal QP shift')
+
+    if Q_err is None:
+        ax.plot(T * 1e3, Q * 1e-3, marker = '.', color = plt.cm.viridis(0),
+                linestyle = '', label = 'Data')
+    else:
+        ax.errorbar(T * 1e3, Q * 1e-3, yerr = Q_err * 1e-3, marker = '.',
+                    color = plt.cm.viridis(0), linestyle = '', label = 'Data')
+        ax.set_xlim(min(T) * 0.96e3, max(T) * 1.04e3)
+
+    xsamp = np.geomspace(min(T), max(T), 200)
+    ysamp = Q_vs_T_qp(xsamp, *popt, gamma = gamma)
+    ax.plot(xsamp * 1e3, ysamp * 1e-3, '--r', label = 'Fit')
+    ylim = ax.get_ylim()
+    ysamp = Q_vs_T_qp(xsamp, *p0, gamma = gamma)
+    ax.plot(xsamp * 1e3, ysamp * 1e-3, ':k', label = 'Guess')
+    ax.set_ylim(ylim)
+    ax.legend(framealpha = 1)
+    return fig, ax
+
+################################################################################
+########################### Resonance shift from TLS ###########################
+################################################################################
+def plot_f_vs_T_tls(T, f, f_err, popt, p0):
+    """
+    Plots the fit and initial guess to f_vs_T_tls.
+
+    Parameters:
+    T (array-like): temperature data in K
+    f (array-like): resonant frequency data in Hz
+    f_err (None or array-like): error bars for the plot, or None to plot
         without error bars
     popt (list): fit parameters
     p0 (list): initial guess parameters
@@ -135,23 +178,108 @@ def plot_fr_vs_temp_tls(temperature, fr, fr_err, popt, p0):
     Returns:
     fig, ax: pyplot figure and axis, or (None, None) if not plotq
     """
-    fig, ax = plt.subplots(figsize = [3, 2.8], dpi = 200, layout = 'tight')
-    ax.set_ylabel(r'$f_r$ (MHz)')
-    ax.set_xlabel(r'Temperature (K)')
-    ax.set_xscale('log')
-    if fr_err is None:
-        ax.plot(temperature, fr * 1e-6, marker = '.', color = plt.cm.viridis(0),
+    f0 = popt[0]
+    fig, ax = setup_f_vs_T(f0)
+    ax.set_title('f vs T, TLS shift')
+
+    if f_err is None:
+        ax.plot(T * 1e3, (f - f0) * 1e-3, marker = '.', color = plt.cm.viridis(0),
                 linestyle = '', label = 'Data')
     else:
-        ax.errorbar(temperature, fr * 1e-6, yerr = fr_err * 1e-6, marker = '.',
+        ax.errorbar(T * 1e3, (f - f0) * 1e-3, yerr = f_err * 1e-3, marker = '.',
                     color = plt.cm.viridis(0), linestyle = '', label = 'Data')
+        ax.set_xlim(min(T) * 0.96e3, max(T) * 1.04e3)
 
-    xsamp = np.geomspace(min(temperature), max(temperature), 200)
-    ysamp = fr_vs_temp_tls(xsamp, *popt)
-    ax.plot(xsamp, ysamp * 1e-6, '--r', label = 'Fit')
+    xsamp = np.geomspace(min(T), max(T), 200)
+    ysamp = f_vs_T_tls(xsamp, *popt)
+    ax.plot(xsamp * 1e3, (ysamp - f0) * 1e-3, '--r', label = 'Fit')
     ylim = ax.get_ylim()
-    ysamp = fr_vs_temp_tls(xsamp, *p0)
-    ax.plot(xsamp, ysamp * 1e-6, ':k', label = 'Guess')
+    ysamp = f_vs_T_tls(xsamp, *p0)
+    ax.plot(xsamp * 1e3, (ysamp - f0) * 1e-3, ':k', label = 'Guess')
     ax.set_ylim(ylim)
-    ax.legend()
+    ax.legend(framealpha = 1)
     return fig, ax
+
+def plot_Q_vs_T_tls(T, Q, Q_err, popt, p0):
+    """
+    Plots the fit and initial guess to Q_vs_T_tls.
+
+    Parameters:
+    T (array-like): temperature data in K
+    Q (array-like): quality factor data
+    Q_err (None or array-like): error bars for the plot, or None to plot
+        without error bars
+    popt (list): fit parameters
+    p0 (list): initial guess parameters
+
+    Returns:
+    fig, ax: pyplot figure and axis, or (None, None) if not plotq
+    """
+    fig, ax = setup_Q_vs_T()
+    ax.set_title('Q vs T, TLS shift')
+
+    if Q_err is None:
+        ax.plot(T * 1e3, Q * 1e-3, marker = '.', color = plt.cm.viridis(0),
+                linestyle = '', label = 'Data')
+    else:
+        ax.errorbar(T * 1e3, Q * 1e-3, yerr = Q_err * 1e-3, marker = '.',
+                    color = plt.cm.viridis(0), linestyle = '', label = 'Data')
+        ax.set_xlim(min(T) * 0.96e3, max(T) * 1.04e3)
+
+    xsamp = np.geomspace(min(T), max(T), 200)
+    ysamp = Q_vs_T_tls(xsamp, *popt)
+    ax.plot(xsamp * 1e3, ysamp * 1e-3, '--r', label = 'Fit')
+    ylim = ax.get_ylim()
+    ysamp = Q_vs_T_tls(xsamp, *p0)
+    ax.plot(xsamp * 1e3, ysamp * 1e-3, ':k', label = 'Guess')
+    ax.set_ylim(ylim)
+    ax.legend(framealpha = 1)
+    return fig, ax
+
+################################################################################
+################################### Utility ####################################
+################################################################################
+def setup_f_vs_T(f0):
+    """
+    Set up an f vs T plot.
+
+    Parameters:
+    f0 (float): frequency at T = 0 K in Hz
+
+    Returns:
+    fig, ax (pyplot figure and axis): formatted figure and axis
+    """
+    fig, ax = plt.subplots(figsize = [5, 4], dpi = 200, layout = 'tight')
+    lbl = r'$(f_r - ' + f'{round(f0 * 1e-6, 3)}' + r'\;\mathrm{MHz})$ (kHz)'
+    ax.set_ylabel(lbl)
+    ax.set_xlabel(r'Temperature (mK)')
+    ax.set_xscale('log')
+    log_without_scientific(ax.xaxis)
+    return fig, ax
+
+def setup_Q_vs_T():
+    """
+    Set up a Q vs T plot.
+
+    Returns:
+    fig, ax (pyplot figure and axis): formatted figure and axis
+    """
+    fig, ax = plt.subplots(figsize = [5, 4], dpi = 200, layout = 'tight')
+    ax.set_ylabel(r'$Q_r/1,000$')
+    ax.set_xlabel(r'Temperature (mK)')
+    ax.set_xscale('log')
+    log_without_scientific(ax.xaxis)
+    return fig, ax
+
+def log_without_scientific(axis):
+    """
+    Turns off scientific notation for a log axis
+
+    Parameters:
+    axis (matplotlib.axis.Xaxis or matplotlib.axis.Yaxis): axis with scaling
+    set to 'log'
+    """
+    axis.set_major_formatter(ScalarFormatter())
+    axis.get_major_formatter().set_scientific(False)
+    axis.set_minor_formatter(ScalarFormatter())
+    axis.get_minor_formatter().set_scientific(False)


### PR DESCRIPTION
Overhaulled res_vs_temp to be consistent with the math in Foote thesis. There are now functions for fitting frequency and quality factor shifts versus temperature from QP density, TLS, and both. I also rewrote the guess functions and they perform much better. Note that these equations use the T << Tc approximation for n_th and the P << Pc for TLS noise. 